### PR TITLE
Moving log from mapping methods to map_new_endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Style/StringLiterals:
   Enabled: true
@@ -11,3 +11,9 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+Metrics/MethodLength:
+  Max: 30
+
+Metrics/AbcSize:
+  Max: 35

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -17,8 +17,8 @@ module MacawFramework
     # @param {Logger} custom_log
     def initialize(custom_log = nil)
       begin
-        config = JSON.parse(File.read('application.json'))
-        @port = config['macaw']['port']
+        config = JSON.parse(File.read("application.json"))
+        @port = config["macaw"]["port"]
       rescue StandardError
         @port ||= 8080
       end
@@ -34,8 +34,7 @@ module MacawFramework
     # @return {Integer, String}
     def get(path, &block)
       path_clean = RequestDataFiltering.extract_path(path)
-      @macaw_log.info("Defining GET endpoint at #{path_clean}")
-      map_new_endpoint('get', path_clean, &block)
+      map_new_endpoint("get", path_clean, &block)
     end
 
     ##
@@ -45,9 +44,8 @@ module MacawFramework
     # @param {Proc} block
     # @return {String, Integer}
     def post(path, &block)
-      path_clean = path[0] == '/' ? path[1..].gsub('/', '_') : path.gsub('/', '_')
-      @macaw_log.info("Defining POST endpoint at #{path_clean}")
-      map_new_endpoint('post', path_clean, &block)
+      path_clean = RequestDataFiltering.extract_path(path)
+      map_new_endpoint("post", path_clean, &block)
     end
 
     ##
@@ -57,9 +55,8 @@ module MacawFramework
     # @param {Proc} block
     # @return {String, Integer}
     def put(path, &block)
-      path_clean = path[0] == '/' ? path[1..].gsub('/', '_') : path.gsub('/', '_')
-      @macaw_log.info("Defining PUT endpoint at #{path_clean}")
-      map_new_endpoint('put', path_clean, &block)
+      path_clean = RequestDataFiltering.extract_path(path)
+      map_new_endpoint("put", path_clean, &block)
     end
 
     ##
@@ -69,9 +66,8 @@ module MacawFramework
     # @param {Proc} block
     # @return {String, Integer}
     def patch(path, &block)
-      path_clean = path[0] == '/' ? path[1..].gsub('/', '_') : path.gsub('/', '_')
-      @macaw_log.info("Defining PATCH endpoint at #{path_clean}")
-      map_new_endpoint('patch', path_clean, &block)
+      path_clean = RequestDataFiltering.extract_path(path)
+      map_new_endpoint("patch", path_clean, &block)
     end
 
     ##
@@ -81,9 +77,8 @@ module MacawFramework
     # @param {Proc} block
     # @return {String, Integer}
     def delete(path, &block)
-      path_clean = path[0] == '/' ? path[1..].gsub('/', '_') : path.gsub('/', '_')
-      @macaw_log.info("Defining DELETE endpoint at #{path_clean}")
-      map_new_endpoint('delete', path_clean, &block)
+      path_clean = path[0] == "/" ? path[1..].gsub("/", "_") : path.gsub("/", "_")
+      map_new_endpoint("delete", path_clean, &block)
     end
 
     ##
@@ -98,10 +93,10 @@ module MacawFramework
           path, method_name, headers, body, parameters = RequestDataFiltering.extract_client_info(client)
           raise EndpointNotMappedError unless respond_to?(method_name)
 
-          @macaw_log.info("Running #{path.gsub("\n", '').gsub("\r", '')}")
+          @macaw_log.info("Running #{path.gsub("\n", "").gsub("\r", "")}")
           message, status = send(method_name, headers, body, parameters)
           status ||= 200
-          message ||= 'Ok'
+          message ||= "Ok"
           client.puts "HTTP/1.1 #{status} #{HTTP_STATUS_CODE_MAP[status]} \r\n\r\n#{message}"
           client.close
         rescue EndpointNotMappedError
@@ -114,14 +109,15 @@ module MacawFramework
         end
       end
     rescue Interrupt
-      @macaw_log.info('Stopping server')
+      @macaw_log.info("Stopping server")
       server.close
-      @macaw_log.info('Macaw stop flying for some seeds...')
+      @macaw_log.info("Macaw stop flying for some seeds...")
     end
 
     private
 
     def map_new_endpoint(prefix, path, &block)
+      @macaw_log.info("Defining #{prefix.upcase} endpoint at /#{path}")
       define_singleton_method("#{prefix}_#{path}", block)
     end
   end

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -4,6 +4,7 @@ require_relative "macaw_framework/endpoint_not_mapped_error"
 require_relative "macaw_framework/request_data_filtering"
 require_relative "macaw_framework/http_status_code"
 require_relative "macaw_framework/version"
+require "logger"
 require "socket"
 require "json"
 

--- a/lib/macaw_framework/endpoint_not_mapped_error.rb
+++ b/lib/macaw_framework/endpoint_not_mapped_error.rb
@@ -4,7 +4,7 @@
 # Error raised when the client calls
 # for a path that doesn't exist.
 class EndpointNotMappedError < StandardError
-  def initialize(msg = 'Undefined endpoint')
+  def initialize(msg = "Undefined endpoint")
     super
   end
 end

--- a/lib/macaw_framework/request_data_filtering.rb
+++ b/lib/macaw_framework/request_data_filtering.rb
@@ -7,18 +7,18 @@ module RequestDataFiltering
   # Method responsible for extracting information
   # provided by the client like Headers and Body
   def self.extract_client_info(client)
-    path, parameters = extract_url_parameters(client.gets.gsub('HTTP/1.1', ''))
-    method_name = path.gsub('/', '_').strip!.downcase
-    method_name.gsub!(' ', '')
+    path, parameters = extract_url_parameters(client.gets.gsub("HTTP/1.1", ""))
+    method_name = path.gsub("/", "_").strip!.downcase
+    method_name.gsub!(" ", "")
     body_first_line, headers = extract_headers(client)
-    body = extract_body(client, body_first_line, headers['Content-Length'].to_i)
+    body = extract_body(client, body_first_line, headers["Content-Length"].to_i)
     [path, method_name, headers, body, parameters]
   end
 
   ##
   # Method responsible for extracting the path from URI
   def self.extract_path(path)
-    path[0] == '/' ? path[1..].gsub('/', '_') : path.gsub('/', '_')
+    path[0] == "/" ? path[1..].gsub("/", "_") : path.gsub("/", "_")
   end
 
   ##
@@ -27,7 +27,7 @@ module RequestDataFiltering
     header = client.gets.delete("\n").delete("\r")
     headers = {}
     while header.match(%r{[a-zA-Z0-9\-/*]*: [a-zA-Z0-9\-/*]})
-      split_header = header.split(':')
+      split_header = header.split(":")
       headers[split_header[0]] = split_header[1][1..]
       header = client.gets.delete("\n").delete("\r")
     end
@@ -46,12 +46,12 @@ module RequestDataFiltering
   def self.extract_url_parameters(http_first_line)
     return http_first_line, nil unless http_first_line =~ /\?/
 
-    path_and_parameters = http_first_line.split('?', 2)
+    path_and_parameters = http_first_line.split("?", 2)
     path = "#{path_and_parameters[0]} "
-    parameters_array = path_and_parameters[1].split('&')
+    parameters_array = path_and_parameters[1].split("&")
     parameters_array.map! do |item|
-      split_item = item.split('=')
-      { split_item[0] => split_item[1].gsub("\n", '').gsub("\r", '').gsub("\s", '') }
+      split_item = item.split("=")
+      { split_item[0] => split_item[1].gsub("\n", "").gsub("\r", "").gsub("\s", "") }
     end
     parameters = {}
     parameters_array.each { |item| parameters.merge!(item) }

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/test/client_data.txt
+++ b/test/client_data.txt
@@ -1,0 +1,9 @@
+GET /test_parameters?param1=11111&param2=22222 HTTP/1.1
+Content-Type: application/json
+Accept: */*
+Host: localhost:8080
+Content-Length: 29
+
+{
+    "testBody": "testing"
+}

--- a/test/test_macaw_framework.rb
+++ b/test/test_macaw_framework.rb
@@ -6,8 +6,4 @@ class TestMacawFramework < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::MacawFramework::VERSION
   end
-
-  def test_it_does_something_useful
-    assert false
-  end
 end

--- a/test/test_macaw_framework.rb
+++ b/test/test_macaw_framework.rb
@@ -1,9 +1,42 @@
 # frozen_string_literal: true
 
-require "test_helper"
+require_relative "test_helper"
 
-class TestMacawFramework < Minitest::Test
+class TestMacawFramework < Minitest::Spec
+  before do
+    @macaw = MacawFramework::Macaw.new
+  end
   def test_that_it_has_a_version_number
     refute_nil ::MacawFramework::VERSION
+  end
+
+  def test_define_get_endpoint
+    assert !@macaw.respond_to?("get_hello_world")
+    @macaw.get("/hello_world") {}
+    assert @macaw.respond_to?("get_hello_world")
+  end
+
+  def test_define_post_endpoint
+    assert !@macaw.respond_to?("post_hello_world")
+    @macaw.post("/hello_world") {}
+    assert @macaw.respond_to?("post_hello_world")
+  end
+
+  def test_define_put_endpoint
+    assert !@macaw.respond_to?("put_hello_world")
+    @macaw.put("/hello_world") {}
+    assert @macaw.respond_to?("put_hello_world")
+  end
+
+  def test_define_patch_endpoint
+    assert !@macaw.respond_to?("patch_hello_world")
+    @macaw.patch("/hello_world") {}
+    assert @macaw.respond_to?("patch_hello_world")
+  end
+
+  def test_define_delete_endpoint
+    assert !@macaw.respond_to?("delete_hello_world")
+    @macaw.delete("/hello_world") {}
+    assert @macaw.respond_to?("delete_hello_world")
   end
 end

--- a/test/test_request_data_filtering.rb
+++ b/test/test_request_data_filtering.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "../lib/macaw_framework/request_data_filtering"
+class TestRequestDataFiltering < Minitest::Test
+  def test_extract_client_info
+    expected_path = "GET /test_parameters "
+    expected_method_name = "get_test_parameters"
+    expected_headers = {
+      "Content-Type" => "application/json",
+      "Accept" => "*/*",
+      "Host" => "localhost",
+      "Content-Length" => "29"
+    }
+    expected_body = "{\n    \"testBody\": \"testing\"\n}"
+    expected_parameters = {
+      "param1" => "11111",
+      "param2" => "22222"
+    }
+
+    filter = RequestDataFiltering
+    client_data = File.open("./test/client_data.txt")
+    path, method_name, headers, body, parameters = filter.extract_client_info(client_data)
+
+    assert path == expected_path
+    assert body == expected_body
+    assert parameters == expected_parameters
+    assert headers == expected_headers
+    assert method_name == expected_method_name
+  end
+end


### PR DESCRIPTION
Moving log from mapping methods to map_new_endpoint

- Refactoring methods from Macaw class for a
cleaner code

- Configuring .rubocop.yml

- Removing dummy tests generated by RubyMine

Adding tests to the code

- Adding unittests to the code using
minitest

- Added require 'logger' to Macaw class