### PR TITLE
Feature/rate limiting middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 /.idea/
 Gemfile.lock
 *.gem
+sonar-project.properties
+/.scannerwork/
+utils.txt

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ gem "minitest", "~> 5.0"
 
 gem "rubocop", "~> 1.21"
 
-gem "simplecov", "~> 0.22.0"
-
 gem "prometheus-client", "~> 4.1"
+
+group :test do
+  gem "simplecov", "~> 0.21.2"
+  gem "simplecov-json"
+  gem "simplecov_json_formatter", "~> 0.1.2"
+end

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # MacawFramework
 
-<img src="macaw_logo.png" alt= “” style="width: 30%;height: 30%;margin-left: 35%">
-
 This is a framework for developing web applications. Please have in mind that this is still a work in progress and
 it is strongly advised to not use it for production purposes for now. Actually it supports only HTTP. and HTTPS/SSL
 support will be implemented soon. Anyone who wishes to contribute is welcome.
@@ -31,6 +29,13 @@ in the same directory of the script that will start the application with the fol
     "threads": 10,
     "cache": {
       "cache_invalidation": 3600
+    },
+    "prometheus": {
+      "endpoint": "/metrics"
+    },
+    "rate_limiting": {
+      "window": 10,
+      "max_requests": 3
     }
   }
 }
@@ -38,6 +43,9 @@ in the same directory of the script that will start the application with the fol
 
 Cache invalidation time should be specified in seconds. In order to enable caching, The application.json file
 should exist in the app main directory and it need the `cache_invalidation` config set.
+
+Rate Limit window should also be specified in seconds. Rate limit will be activated only if the `rate_limiting` config
+exists inside `application.json`.
 
 Example of usage:
 

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -18,7 +18,7 @@ module MacawFramework
   class Macaw
     ##
     # Array containing the routes defined in the application
-    attr_reader :routes
+    attr_reader :routes, :port, :bind, :threads, :macaw_log
 
     ##
     # @param {Logger} custom_log
@@ -45,8 +45,7 @@ module MacawFramework
       @endpoints_to_cache = []
       @prometheus ||= nil
       @prometheus_middleware ||= nil
-      @server = server.new(self, @macaw_log, @port, @bind, @threads, @endpoints_to_cache, @cache, @prometheus,
-                           @prometheus_middleware)
+      @server = server.new(self, @endpoints_to_cache, @cache, @prometheus, @prometheus_middleware)
     end
 
     ##

--- a/lib/macaw_framework/aspects/cache_aspect.rb
+++ b/lib/macaw_framework/aspects/cache_aspect.rb
@@ -3,12 +3,12 @@
 ##
 # Aspect that provide cache for the endpoints.
 module CacheAspect
-  def call_endpoint(cache, endpoints_to_cache, *args)
-    return super(*args) unless endpoints_to_cache.include?(args[0]) && !cache.nil?
-    return cache.cache[args[2..].to_s.to_sym][0] unless cache.cache[args[2..].to_s.to_sym].nil?
+  def call_endpoint(cache, *args)
+    return super(*args) unless !cache[:cache].nil? && cache[:endpoints_to_cache].include?(args[0])
+    return cache[:cache].cache[args[1..].to_s.to_sym][0] unless cache[:cache].cache[args[1..].to_s.to_sym].nil?
 
     response = super(*args)
-    cache.cache[args[2..].to_s.to_sym] = [response, Time.now]
+    cache[:cache].cache[args[1..].to_s.to_sym] = [response, Time.now]
     response
   end
 end

--- a/lib/macaw_framework/aspects/cache_aspect.rb
+++ b/lib/macaw_framework/aspects/cache_aspect.rb
@@ -5,10 +5,13 @@
 module CacheAspect
   def call_endpoint(cache, *args)
     return super(*args) unless !cache[:cache].nil? && cache[:endpoints_to_cache].include?(args[0])
-    return cache[:cache].cache[args[1..].to_s.to_sym][0] unless cache[:cache].cache[args[1..].to_s.to_sym].nil?
 
-    response = super(*args)
-    cache[:cache].cache[args[1..].to_s.to_sym] = [response, Time.now]
-    response
+    cache[:cache].mutex.synchronize do
+      return cache[:cache].cache[args[1..].to_s.to_sym][0] unless cache[:cache].cache[args[1..].to_s.to_sym].nil?
+
+      response = super(*args)
+      cache[:cache].cache[args[1..].to_s.to_sym] = [response, Time.now]
+      response
+    end
   end
 end

--- a/lib/macaw_framework/aspects/logging_aspect.rb
+++ b/lib/macaw_framework/aspects/logging_aspect.rb
@@ -8,8 +8,8 @@ require "logger"
 # in the framework.
 module LoggingAspect
   def call_endpoint(logger, *args)
-    endpoint_name = args[2].split(".")[1..].join("/")
-    logger.info("Request received for #{endpoint_name} with arguments: #{args[3..]}")
+    endpoint_name = args[1].split(".")[1..].join("/")
+    logger.info("Request received for #{endpoint_name} with arguments: #{args[2..]}")
 
     begin
       response = super(*args)

--- a/lib/macaw_framework/aspects/prometheus_aspect.rb
+++ b/lib/macaw_framework/aspects/prometheus_aspect.rb
@@ -13,7 +13,7 @@ module PrometheusAspect
     ensure
       duration = (Time.now - start_time) * 1_000
 
-      endpoint_name = args[3].split(".").join("/")
+      endpoint_name = args[2].split(".").join("/")
 
       prometheus_middleware.request_duration_milliseconds.with_labels(endpoint: endpoint_name).observe(duration)
       prometheus_middleware.request_count.with_labels(endpoint: endpoint_name).increment

--- a/lib/macaw_framework/core/server.rb
+++ b/lib/macaw_framework/core/server.rb
@@ -24,17 +24,16 @@ class Server
   # @param {CachingMiddleware} cache
   # @param {Prometheus::Client:Registry} prometheus
   # @return {Server}
-  def initialize(macaw, logger, port, bind, num_threads, endpoints_to_cache = nil, cache = nil, prometheus = nil,
-                 prometheus_middleware = nil)
-    @port = port
-    @bind = bind
+  def initialize(macaw, endpoints_to_cache = nil, cache = nil, prometheus = nil, prometheus_mw = nil)
+    @port = macaw.port
+    @bind = macaw.bind
     @macaw = macaw
-    @macaw_log = logger
-    @num_threads = num_threads
+    @macaw_log = macaw.macaw_log
+    @num_threads = macaw.threads
     @work_queue = Queue.new
     @cache = { cache: cache, endpoints_to_cache: endpoints_to_cache || [] }
     @prometheus = prometheus
-    @prometheus_middleware = prometheus_middleware
+    @prometheus_middleware = prometheus_mw
     @workers = []
   end
 

--- a/lib/macaw_framework/errors/too_many_requests_error.rb
+++ b/lib/macaw_framework/errors/too_many_requests_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class TooManyRequestsError < StandardError
+end

--- a/lib/macaw_framework/middlewares/caching_middleware.rb
+++ b/lib/macaw_framework/middlewares/caching_middleware.rb
@@ -4,15 +4,18 @@
 # Middleware responsible for storing and
 # invalidating cache.
 class CachingMiddleware
-  attr_accessor :cache
+  attr_accessor :cache, :mutex
 
   def initialize(inv_time_seconds = 3_600)
     @cache = {}
+    @mutex = Mutex.new
     Thread.new do
       loop do
         sleep(1)
-        @cache.each_pair do |key, value|
-          @cache.delete(key) if Time.now - value[1] >= inv_time_seconds
+        @mutex.synchronize do
+          @cache.each_pair do |key, value|
+            @cache.delete(key) if Time.now - value[1] >= inv_time_seconds
+          end
         end
       end
     end

--- a/lib/macaw_framework/middlewares/rate_limiter_middleware.rb
+++ b/lib/macaw_framework/middlewares/rate_limiter_middleware.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+##
+# Middleware responsible for implementing
+# rate limiting
+class RateLimiterMiddleware
+  attr_reader :window_size, :max_requests
+
+  def initialize(window_size, max_requests)
+    @window_size = window_size
+    @max_requests = max_requests
+    @client_timestamps = Hash.new { |key, value| key[value] = [] }
+    @mutex = Mutex.new
+  end
+
+  def allow?(client_id)
+    @mutex.synchronize do
+      now = Time.now.to_i
+      timestamps = @client_timestamps[client_id]
+
+      timestamps.reject! { |timestamp| timestamp <= now - window_size }
+
+      if timestamps.length < max_requests
+        timestamps << now
+        true
+      else
+        false
+      end
+    end
+  end
+end

--- a/sig/macaw_framework/macaw.rbs
+++ b/sig/macaw_framework/macaw.rbs
@@ -1,17 +1,21 @@
 module MacawFramework
   class Macaw
-    @bind: string
+    @bind: String
     @cache: untyped
     @endpoints_to_cache: Array[String]
     @macaw_log: Logger
-    @port: int
 
     @prometheus: untyped
     @server: Server
 
     @threads: Integer
 
+    attr_reader bind: String
+    attr_reader macaw_log: Logger
+    attr_reader port: Integer
     attr_reader routes: Array[String]
+
+    attr_reader threads: Integer
 
     def delete: -> nil
 

--- a/sig/macaw_framework/macaw.rbs
+++ b/sig/macaw_framework/macaw.rbs
@@ -2,15 +2,18 @@ module MacawFramework
   class Macaw
     @bind: String
     @cache: untyped
+    @config: Hash[String, untyped]
     @endpoints_to_cache: Array[String]
     @macaw_log: Logger
 
     @prometheus: untyped
+    @prometheus_middleware: untyped
     @server: Server
 
     @threads: Integer
 
     attr_reader bind: String
+    attr_reader config: Hash[String, untyped]
     attr_reader macaw_log: Logger
     attr_reader port: Integer
     attr_reader routes: Array[String]

--- a/sig/server.rbs
+++ b/sig/server.rbs
@@ -1,6 +1,6 @@
 class Server
   @bind: String
-  @cache: CachingMiddleware
+  @cache: Hash[Symbol, Array]
   @endpoints_to_cache: Array[String]
   @macaw: MacawFramework::Macaw
   @macaw_log: Logger

--- a/test/test_cache_aspect.rb
+++ b/test/test_cache_aspect.rb
@@ -22,7 +22,7 @@ end
 class TestCacheAspect < Minitest::Test
   def test_no_cache
     test_class = TestClass.new
-    response = test_class.call_endpoint(nil, "method1", "a", "a", "a")
+    response = test_class.call_endpoint({ cache: nil, endpoints_to_cache: nil }, "method1", { body: "a", headers: "a" })
 
     assert_equal "Original method response", response
   end
@@ -31,7 +31,8 @@ class TestCacheAspect < Minitest::Test
     test_class = TestClass.new
     cache = CacheMock.new
     endpoints_to_cache = ["method2"]
-    response = test_class.call_endpoint(cache, endpoints_to_cache, "a", "a", "a")
+    response = test_class.call_endpoint({ cache: cache, endpoints_to_cache: endpoints_to_cache }, endpoints_to_cache,
+                                        "a", { body: "a", headers: "a" })
 
     assert_equal "Original method response", response
   end
@@ -40,8 +41,11 @@ class TestCacheAspect < Minitest::Test
     test_class = TestClass.new
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
-    cache.cache[:"[\"a\", \"a\"]"] = ["Cached response", Time.now]
-    response = test_class.call_endpoint(cache, endpoints_to_cache, "method1", "a", "a", "a")
+    cache.cache[:"[{:body=>\"a\", :headers=>\"a\"}]"] = ["Cached response", Time.now]
+    response = test_class.call_endpoint(
+      { cache: cache, endpoints_to_cache: endpoints_to_cache },
+      "method1", { body: "a", headers: "a" }
+    )
 
     assert_equal "Cached response", response
   end
@@ -50,9 +54,12 @@ class TestCacheAspect < Minitest::Test
     test_class = TestClass.new
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
-    response = test_class.call_endpoint(cache, endpoints_to_cache, "method1", "a", "a", "a")
+    response = test_class.call_endpoint(
+      { cache: cache, endpoints_to_cache: endpoints_to_cache },
+      "method1", { body: "a", headers: "a" }
+    )
 
     assert_equal "Original method response", response
-    assert_equal("Original method response", cache.cache[:"[\"a\", \"a\"]"][0])
+    assert_equal("Original method response", cache.cache[:"[{:body=>\"a\", :headers=>\"a\"}]"][0])
   end
 end

--- a/test/test_cache_aspect.rb
+++ b/test/test_cache_aspect.rb
@@ -12,10 +12,11 @@ class TestClass
 end
 
 class CacheMock
-  attr_accessor :cache
+  attr_accessor :cache, :mutex
 
   def initialize
     @cache = {}
+    @mutex = Mutex.new
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require "simplecov"
+require "simplecov_json_formatter"
+
+SimpleCov.root(File.join(File.dirname(__FILE__), ".."))
+SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "macaw_framework"
 

--- a/test/test_rate_limiter_middleware.rb
+++ b/test/test_rate_limiter_middleware.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../lib/macaw_framework/middlewares/rate_limiter_middleware"
+
+class TestRateLimiterMiddleware < Minitest::Test
+  def setup
+    @window_size = 10
+    @max_requests = 5
+    @rate_limiter = RateLimiterMiddleware.new(@window_size, @max_requests)
+    @client_id = "127.0.0.1"
+  end
+
+  def test_allow_within_limits
+    @max_requests.times do
+      assert_equal true, @rate_limiter.allow?(@client_id)
+    end
+  end
+
+  def test_reject_when_exceeding_limits
+    @max_requests.times { @rate_limiter.allow?(@client_id) }
+    assert_equal false, @rate_limiter.allow?(@client_id)
+  end
+
+  def test_allow_after_window_passed
+    @max_requests.times { @rate_limiter.allow?(@client_id) }
+    sleep(@window_size + 1)
+    assert_equal true, @rate_limiter.allow?(@client_id)
+  end
+
+  def test_allow_different_clients
+    client_id2 = "127.0.0.2"
+    @max_requests.times do
+      assert_equal true, @rate_limiter.allow?(@client_id)
+      assert_equal true, @rate_limiter.allow?(client_id2)
+    end
+  end
+end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -9,10 +9,14 @@ require_relative "../lib/macaw_framework/data_filters/request_data_filtering"
 require_relative "../lib/macaw_framework/errors/endpoint_not_mapped_error"
 
 class TestEndpoint
-  attr_reader :routes
+  attr_reader :routes, :port, :bind, :threads, :macaw_log
 
   def initialize
     @routes = %w[get.hello get.ok get.ise]
+    @port = 9292
+    @bind = "localhost"
+    @threads = 4
+    @macaw_log = Logger.new($stdout)
     define_singleton_method("get.hello", ->(_context) { "Hello, World!" })
     define_singleton_method("get.ok", ->(_context) { ["Ok", 200] })
     define_singleton_method("get.ise", ->(_context) { raise StandardError, "Internal server error" })
@@ -42,7 +46,7 @@ class ServerTest < Minitest::Test
     @port = 9292
     @bind = "localhost"
     @num_threads = 4
-    @server = Server.new(@macaw, @logger, @port, @bind, @num_threads)
+    @server = Server.new(@macaw)
   end
 
   def teardown


### PR DESCRIPTION
Implementing Rate Limiting Middleware

- In order to provide a simple security
measure against Denial of Service
attacks, a middleware for rate limiting
was implemented. It can be configured
via application.json for time window
and max requests.

- The middleware is optional and will be
active only if the configurations
are provided in the application.json file.

- It is a simple middleware for single
instances applications. In the case
of distributed systems and containerized
environments it's recommended to implement
rate limiting in the Load Balancer layer.

Making Cache Aspect and Middleware thread safe

- In order to ensure thread safety, Mutex
synchronization was introduced in both
the aspect and the middleware