### PR TITLE
Improving caching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,21 @@ in the same directory of the script that will start the application with the fol
     },
     "rate_limiting": {
       "window": 10,
-      "max_requests": 3
+      "max_requests": 3,
+      "ignore_headers": [
+        "header-to-be-ignored-from-caching-strategy",
+        "another-header-to-be-ignored-from-caching-strategy"
+      ]
     }
   }
 }
 ```
 
 Cache invalidation time should be specified in seconds. In order to enable caching, The application.json file
-should exist in the app main directory and it need the `cache_invalidation` config set.
+should exist in the app main directory and it need the `cache_invalidation` config set. It is possible to
+provide a list of strings in the property `ignore_headers`. All the client headers with the same name of any
+of the strings provided will be ignored from caching strategy. This is useful to exclude headers like 
+correlation IDs from the caching strategy.
 
 Rate Limit window should also be specified in seconds. Rate limit will be activated only if the `rate_limiting` config
 exists inside `application.json`.

--- a/lib/macaw_framework/aspects/cache_aspect.rb
+++ b/lib/macaw_framework/aspects/cache_aspect.rb
@@ -6,12 +6,21 @@ module CacheAspect
   def call_endpoint(cache, *args)
     return super(*args) unless !cache[:cache].nil? && cache[:endpoints_to_cache].include?(args[0])
 
+    cache_filtered_name = cache_name_filter(args[1], cache[:ignored_headers])
+
     cache[:cache].mutex.synchronize do
-      return cache[:cache].cache[args[1..].to_s.to_sym][0] unless cache[:cache].cache[args[1..].to_s.to_sym].nil?
+      return cache[:cache].cache[cache_filtered_name][0] unless cache[:cache].cache[cache_filtered_name].nil?
 
       response = super(*args)
-      cache[:cache].cache[args[1..].to_s.to_sym] = [response, Time.now]
+      cache[:cache].cache[cache_filtered_name] = [response, Time.now]
       response
     end
+  end
+
+  private
+
+  def cache_name_filter(client_data, ignored_headers)
+    filtered_headers = client_data[:headers].filter { |key, _value| !ignored_headers.include?(key) }
+    [{ body: client_data[:body], params: client_data[:params], headers: filtered_headers }].to_s.to_sym
   end
 end

--- a/lib/macaw_framework/core/server.rb
+++ b/lib/macaw_framework/core/server.rb
@@ -34,13 +34,15 @@ class Server
     @num_threads = macaw.threads
     @work_queue = Queue.new
     if @macaw.config&.dig("macaw", "rate_limiting")
+      ignored_headers = @macaw.config["macaw"]["rate_limiting"]["ignore_headers"] || []
       @rate_limit = RateLimiterMiddleware.new(
         @macaw.config["macaw"]["rate_limiting"]["window"].to_i || 1,
         @macaw.config["macaw"]["rate_limiting"]["max_requests"].to_i || 60
       )
     end
     @rate_limit ||= nil
-    @cache = { cache: cache, endpoints_to_cache: endpoints_to_cache || [] }
+    ignored_headers ||= nil
+    @cache = { cache: cache, endpoints_to_cache: endpoints_to_cache || [], ignored_headers: ignored_headers }
     @prometheus = prometheus
     @prometheus_middleware = prometheus_mw
     @workers = []


### PR DESCRIPTION
- Add a new configuration option in the cache section in 
the application.json file, called ignore_headers which 
will accept an array of header names that should not be
considered when determining cache usage