### PR TITLE
Fixing a bug of noMethodError in cache aspect

### DIFF
--- a/lib/macaw_framework/aspects/cache_aspect.rb
+++ b/lib/macaw_framework/aspects/cache_aspect.rb
@@ -4,7 +4,7 @@
 # Aspect that provide cache for the endpoints.
 module CacheAspect
   def call_endpoint(cache, *args)
-    return super(*args) unless !cache[:cache].nil? && cache[:endpoints_to_cache].include?(args[0])
+    return super(*args) unless !cache[:cache].nil? && cache[:endpoints_to_cache]&.include?(args[0])
 
     cache_filtered_name = cache_name_filter(args[1], cache[:ignored_headers])
 
@@ -20,7 +20,7 @@ module CacheAspect
   private
 
   def cache_name_filter(client_data, ignored_headers)
-    filtered_headers = client_data[:headers].filter { |key, _value| !ignored_headers.include?(key) }
+    filtered_headers = client_data[:headers].filter { |key, _value| !ignored_headers&.include?(key) }
     [{ body: client_data[:body], params: client_data[:params], headers: filtered_headers }].to_s.to_sym
   end
 end


### PR DESCRIPTION
- When the ignore_headers configuration where not provided in the application.json while cache was active, this generated an error of noMethodError when trying to process cache strategy. Null safety operators on the array search corrected the problem.