### PR TITLE
Fixing cache ignored headers documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ in the same directory of the script that will start the application with the fol
     "bind": "localhost",
     "threads": 10,
     "cache": {
-      "cache_invalidation": 3600
+      "cache_invalidation": 3600,
+      "ignore_headers": [
+        "header-to-be-ignored-from-caching-strategy",
+        "another-header-to-be-ignored-from-caching-strategy"
+      ]
     },
     "prometheus": {
       "endpoint": "/metrics"
     },
     "rate_limiting": {
       "window": 10,
-      "max_requests": 3,
-      "ignore_headers": [
-        "header-to-be-ignored-from-caching-strategy",
-        "another-header-to-be-ignored-from-caching-strategy"
-      ]
+      "max_requests": 3
     },
     "ssl": {
       "ssl": {

--- a/lib/macaw_framework/core/server.rb
+++ b/lib/macaw_framework/core/server.rb
@@ -34,7 +34,8 @@ class Server
     @macaw_log = macaw.macaw_log
     @num_threads = macaw.threads
     @work_queue = Queue.new
-    ignored_headers = set_rate_limiting
+    ignored_headers = set_cache_ignored_h
+    set_rate_limiting
     set_ssl
     @rate_limit ||= nil
     ignored_headers ||= nil
@@ -107,12 +108,18 @@ class Server
   end
 
   def set_rate_limiting
-    if @macaw.config&.dig("macaw", "rate_limiting")
-      ignored_headers = @macaw.config["macaw"]["rate_limiting"]["ignore_headers"] || []
-      @rate_limit = RateLimiterMiddleware.new(
-        @macaw.config["macaw"]["rate_limiting"]["window"].to_i || 1,
-        @macaw.config["macaw"]["rate_limiting"]["max_requests"].to_i || 60
-      )
+    return unless @macaw.config&.dig("macaw", "rate_limiting")
+
+    @rate_limit = RateLimiterMiddleware.new(
+      @macaw.config["macaw"]["rate_limiting"]["window"].to_i || 1,
+      @macaw.config["macaw"]["rate_limiting"]["max_requests"].to_i || 60
+    )
+  end
+
+  def set_cache_ignored_h
+    ignored_headers = nil
+    if @macaw.config&.dig("macaw", "cache", "ignored_headers")
+      ignored_headers = @macaw.config["macaw"]["cache"]["ignore_headers"] || []
     end
     ignored_headers
   end


### PR DESCRIPTION
- In the documentation and in the code, the ignored_headers array was expected inside the rate limiting configuration, which was a design mistake. This commit corrects it moving the configuration to the cache configuration.