### PR TITLE
Fixing issue of ignored headers not being fetched from config

### DIFF
--- a/lib/macaw_framework/core/server.rb
+++ b/lib/macaw_framework/core/server.rb
@@ -123,11 +123,9 @@ class Server
   end
 
   def set_cache_ignored_h
-    ignored_headers = []
-    if @macaw.config&.dig("macaw", "cache", "ignored_headers")
-      ignored_headers = @macaw.config["macaw"]["cache"]["ignore_headers"] || []
-    end
-    ignored_headers
+    return unless @macaw.config&.dig("macaw", "cache", "ignore_headers")
+
+    @macaw.config["macaw"]["cache"]["ignore_headers"] || []
   end
 
   def set_ssl
@@ -166,13 +164,13 @@ class Server
       {
         headers: client_data[:headers],
         body: client_data[:body],
-        params: client_data[:parameters],
+        params: client_data[:params],
         client: @session[client_ip][0]
       }
     )
   end
 
   def get_client_data(body, headers, parameters)
-    { body: body, headers: headers, parameters: parameters }
+    { body: body, headers: headers, params: parameters }
   end
 end


### PR DESCRIPTION
- The current implementation of the code to fetch the 
ignored headers from the configuration file has a typo, which is
 causing the wrong key to be used when
 fetching the value. As a result, the code
 always returns an empty array, even when
 the value is defined in the configuration
 file. The correction was made by renaming
 the parameter.

 - Also, the current implementation of the cache feature has a 
 bug that is causing inconsistent behavior with query parameters. 
The issue is caused by a misspelled symbol, which is leading to 
different cache keys being generated for the same request with 
different query parameters. The correction was the same 
from the issue above.