### PR TITLE
Implementing support for min and max SSL version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,15 @@ on:
   push:
     branches:
       - main
+      - development
 
   pull_request:
+    branches:
+      - development
+    types:
+      - opened
+      - synchronize
+      - edited
 
 jobs:
   build:

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem "rubocop", "~> 1.21"
 
 gem "prometheus-client", "~> 4.1"
 
+gem "openssl"
+
 group :test do
   gem "simplecov", "~> 0.21.2"
   gem "simplecov-json"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ end
       "max_requests": 3
     },
     "ssl": {
+      "min": "SSL3",
+      "max": "TLS1.3",
       "cert_file_name": "path/to/cert/file/file.crt",
       "key_file_name": "path/to/cert/key/file.key"
     }
@@ -134,6 +136,8 @@ exists inside `application.json`.
 
 If the SSL configuration is provided in the `application.json` file with valid certificate and key files, the TCP server
 will be wrapped with HTTPS security using the provided certificate.
+
+The supported values for `min` and `max` in the SSL configuration are: `SSL2`, `SSL3`, `TLS1.1`, `TLS1.2` and `TLS1.3`
 
 If prometheus is enabled, a get endpoint will be defined at path `/metrics` to collect prometheus metrics. This path
 is configurable via the `application.json` file.

--- a/lib/macaw_framework/utils/supported_ssl_versions.rb
+++ b/lib/macaw_framework/utils/supported_ssl_versions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "openssl"
+
+module SupportedSSLVersions
+  VERSIONS = {
+    "SSL2" => OpenSSL::SSL::SSL2_VERSION,
+    "SSL3" => OpenSSL::SSL::SSL3_VERSION,
+    "TLS1.1" => OpenSSL::SSL::TLS1_1_VERSION,
+    "TLS1.2" => OpenSSL::SSL::TLS1_2_VERSION,
+    "TLS1.3" => OpenSSL::SSL::TLS1_3_VERSION
+  }.freeze
+end


### PR DESCRIPTION
- Now the developer can configure (via the application.json fil) the minimum and
maximum accepted version of SSL to secure
connections.