### PR TITLE
Creating log sanitization to prevent log forging

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ end
     "port": 8080,
     "bind": "localhost",
     "threads": 10,
+    "log": {
+      "max_length": 1024,
+      "sensitive_fields": [
+        "password"
+      ]
+    },
     "cache": {
       "cache_invalidation": 3600,
       "ignore_headers": [

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -37,7 +37,7 @@ module MacawFramework
         @prometheus_middleware = PrometheusMiddleware.new if @config["macaw"]["prometheus"]
         @prometheus_middleware.configure_prometheus(@prometheus, @config, self) if @config["macaw"]["prometheus"]
       rescue StandardError => e
-        @macaw_log.error(e.message)
+        @macaw_log.warn(e.message)
       end
       @port ||= 8080
       @bind ||= "localhost"

--- a/lib/macaw_framework/aspects/logging_aspect.rb
+++ b/lib/macaw_framework/aspects/logging_aspect.rb
@@ -1,6 +1,7 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 require "logger"
+require_relative "../data_filters/log_data_filter"
 
 ##
 # This Aspect is responsible for logging
@@ -9,13 +10,17 @@ require "logger"
 module LoggingAspect
   def call_endpoint(logger, *args)
     endpoint_name = args[1].split(".")[1..].join("/")
-    logger.info("Request received for #{endpoint_name} with arguments: #{args[2..]}")
+    logger.info(LogDataFilter.sanitize_for_logging(
+                  "Request received for #{endpoint_name} with arguments: #{args[2..]}"
+                ))
 
     begin
       response = super(*args)
-      logger.info("Response for #{endpoint_name}: #{response}")
+      logger.info(LogDataFilter.sanitize_for_logging("Response for #{endpoint_name}: #{response}"))
     rescue StandardError => e
-      logger.error("Error processing #{endpoint_name}: #{e.message}\n#{e.backtrace.join("\n")}")
+      logger.error(
+        LogDataFilter.sanitize_for_logging("Error processing #{endpoint_name}: #{e.message}\n#{e.backtrace.join("\n")}")
+      )
       raise e
     end
 

--- a/lib/macaw_framework/data_filters/log_data_filter.rb
+++ b/lib/macaw_framework/data_filters/log_data_filter.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: false
+
+require "json"
+
+##
+# Module responsible for sanitizing log data
+module LogDataFilter
+  DEFAULT_MAX_LENGTH = 512
+  DEFAULT_SENSITIVE_FIELDS = [].freeze
+
+  def self.config
+    @config ||= begin
+      file_path = "application.json"
+      config = {
+        max_length: DEFAULT_MAX_LENGTH,
+        sensitive_fields: DEFAULT_SENSITIVE_FIELDS
+      }
+
+      if File.exist?(file_path)
+        json = JSON.parse(File.read(file_path))
+
+        if json["macaw"] && json["macaw"]["log"]
+          log_config = json["macaw"]["log"]
+          config[:max_length] = log_config["max_length"] if log_config["max_length"]
+          config[:sensitive_fields] = log_config["sensitive_fields"] if log_config["sensitive_fields"]
+        end
+      end
+
+      config
+    end
+  end
+
+  def self.sanitize_for_logging(data, sensitive_fields: config[:sensitive_fields])
+    return "" if data.nil?
+
+    data = data.to_s.force_encoding("UTF-8")
+    data = data.gsub(/[\x00-\x1F\x7F]/, "")
+    data = data.gsub(/\s+/, " ")
+    data = data.slice(0, config[:max_length])
+
+    sensitive_fields.each do |field|
+      next unless data.include?(field.to_s)
+
+      data = data.gsub(/(#{Regexp.escape(field.to_s)}\s*[:=]\s*)([^\s]+)/) do |_match|
+        "#{::Regexp.last_match(1)}#{Digest::SHA256.hexdigest(::Regexp.last_match(2))}"
+      end
+    end
+
+    data
+  end
+end

--- a/lib/macaw_framework/data_filters/request_data_filtering.rb
+++ b/lib/macaw_framework/data_filters/request_data_filtering.rb
@@ -114,6 +114,6 @@ module RequestDataFiltering
   # Method responsible for sanitizing the parameter value
   def self.sanitize_parameter_value(value)
     value.gsub(/[^\w\s]/, "")
-    value.gsub(/[\r\n\s]/, "")
+    value.gsub(/\s/, "")
   end
 end

--- a/test/test_log_data_filter.rb
+++ b/test/test_log_data_filter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: false
+
+require_relative "test_helper"
+require_relative "../lib/macaw_framework/data_filters/log_data_filter"
+
+class TestLogDataFilter < Minitest::Test
+  def test_sanitize_for_logging_without_sensitive_fields
+    data = "This is a test string without sensitive fields."
+    sanitized_data = LogDataFilter.sanitize_for_logging(data)
+
+    assert_equal data, sanitized_data
+  end
+
+  def test_sanitize_for_logging_with_sensitive_fields
+    data = "This is a test string with sensitive fields: password=my_password api_key=my_api_key"
+    sensitive_fields = %w[password api_key]
+    sanitized_data = LogDataFilter.sanitize_for_logging(data, sensitive_fields: sensitive_fields)
+
+    refute_equal data, sanitized_data
+    refute sanitized_data.include?("my_password")
+    refute sanitized_data.include?("my_api_key")
+  end
+
+  def test_sanitize_for_logging_truncate_data
+    long_data = "A" * 600
+    truncated_data = "A" * LogDataFilter.config[:max_length]
+
+    sanitized_data = LogDataFilter.sanitize_for_logging(long_data)
+    assert_equal truncated_data, sanitized_data
+  end
+
+  def test_sanitize_for_logging_remove_control_characters
+    data_with_control_chars = "This is a test\0string\rwith\ncontrol\x1Fcharacters."
+    data_without_control_chars = "This is a teststringwithcontrolcharacters."
+
+    sanitized_data = LogDataFilter.sanitize_for_logging(data_with_control_chars)
+    assert_equal data_without_control_chars, sanitized_data
+  end
+end

--- a/test/test_logging_aspect.rb
+++ b/test/test_logging_aspect.rb
@@ -1,8 +1,9 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 require "logger"
 require_relative "test_helper"
 require_relative "../lib/macaw_framework/aspects/logging_aspect"
+require_relative "../lib/macaw_framework/data_filters/log_data_filter"
 
 class LoggingAspectTest < Minitest::Test
   include LoggingAspect
@@ -11,13 +12,20 @@ class LoggingAspectTest < Minitest::Test
     @logger = Logger.new($stdout)
   end
 
-  def test_logs_input_and_output
+  def test_logs_sanitized_input_and_output
     args = %w[arg1 arg2]
+    sensitive_data = "password=my_password"
+    input_data = "Input of my_endpoint: #{args} #{sensitive_data}"
+    output_data = "Output of my_endpoint: some response"
+
+    sanitized_input_data = LogDataFilter.sanitize_for_logging(input_data)
+    sanitized_output_data = LogDataFilter.sanitize_for_logging(output_data)
+
     @logger.stub(:info, nil) do |msg|
       if msg.is_a?(String) && msg.start_with?("Input of my_endpoint:")
-        assert_match(/#{args}/, msg)
+        assert_equal sanitized_input_data, msg
       elsif msg.is_a?(String) && msg.start_with?("Output of my_endpoint:")
-        assert_equal "Output of my_endpoint: some response", msg
+        assert_equal sanitized_output_data, msg
       end
     end
 

--- a/test/test_macaw_framework.rb
+++ b/test/test_macaw_framework.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "net/http"
 
 class TestMacawFramework < Minitest::Spec
   before do
@@ -38,5 +39,23 @@ class TestMacawFramework < Minitest::Spec
     assert !@macaw.respond_to?("delete.hello_world")
     @macaw.delete("/hello_world") {}
     assert @macaw.respond_to?("delete.hello_world")
+  end
+
+  def test_initialize_with_custom_logger
+    custom_logger = Logger.new($stdout)
+    macaw = MacawFramework::Macaw.new(custom_log: custom_logger)
+    assert_equal custom_logger, macaw.macaw_log
+  end
+
+  def test_endpoint_cache_configuration
+    macaw = MacawFramework::Macaw.new
+    macaw.get("/cache_test", cache: true) {}
+    assert_includes macaw.instance_variable_get(:@endpoints_to_cache), "get.cache_test"
+  end
+
+  def test_endpoint_without_cache_configuration
+    macaw = MacawFramework::Macaw.new
+    macaw.get("/no_cache_test") {}
+    refute_includes macaw.instance_variable_get(:@endpoints_to_cache), "get.no_cache_test"
   end
 end

--- a/test/test_request_data_filtering.rb
+++ b/test/test_request_data_filtering.rb
@@ -92,4 +92,50 @@ class TestRequestDataFiltering < Minitest::Test
     client_data = File.open("./test/data/client_data_path_variable.txt")
     assert_raises(EndpointNotMappedError) { filter.parse_request_data(client_data, [expected_method_name]) }
   end
+
+  def test_sanitize_method_name
+    filter = RequestDataFiltering
+
+    assert_equal "get.test", filter.sanitize_method_name("GET /test ")
+    assert_equal "post.user.profile", filter.sanitize_method_name("POST /user/profile ")
+    assert_equal "put.items.123", filter.sanitize_method_name("PUT /items/123 ")
+  end
+
+  def test_extract_headers
+    filter = RequestDataFiltering
+
+    header_data1 = "Content-Type: application/json\r\nAccept: */*\r\nHost: localhost\r\nContent-Length: 29\r\n\r\n"
+    header_data2 = "Cache-Control: no-cache\r\nPragma: no-cache\r\nExpires: -1\r\n\r\n"
+
+    expected_headers1 = {
+      "Content-Type" => "application/json",
+      "Accept" => "*/*",
+      "Host" => "localhost",
+      "Content-Length" => "29"
+    }
+
+    expected_headers2 = {
+      "Cache-Control" => "no-cache",
+      "Pragma" => "no-cache",
+      "Expires" => "-1"
+    }
+
+    header_io1 = StringIO.new(header_data1)
+    header_io2 = StringIO.new(header_data2)
+
+    _, headers1 = filter.extract_headers(header_io1)
+    _, headers2 = filter.extract_headers(header_io2)
+
+    assert_equal expected_headers1, headers1
+    assert_equal expected_headers2, headers2
+  end
+
+  def test_sanitize_parameters
+    filter = RequestDataFiltering
+
+    assert_equal "parameter1", filter.sanitize_parameter_name("parameter1")
+    assert_equal "parameter1", filter.sanitize_parameter_name("parameter1&$^#%")
+    assert_equal "123value", filter.sanitize_parameter_value("123value")
+    assert_equal "123value", filter.sanitize_parameter_value("123value\n ")
+  end
 end


### PR DESCRIPTION
- In order to filter logs to prevent log forging attacks and to make them more legible, the
module LogDataFilter was created. It will sanitize every log registered by the logging aspect.

- Also, more tests were created for Macaw class and Request Data Filter module.