### PR TITLE
Potentially fixing the thread starvation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,7 @@
 ## [1.0.4] - 2023-05-11
 
 - Fixing issue with response body returning always a blank line at the beginning
+
+## [1.0.5] - 2023-05-12
+
+- Fixing critical bug where threads were being killed and not respawning after abrupt client connection shutdown

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -324,4 +324,22 @@ class ServerTest < Minitest::Test
     end
     @server = nil
   end
+
+  def test_data_filtering
+    @macaw.routes << "post.test_filter"
+    @macaw.define_singleton_method("post.test_filter", ->(context) { context[:body] })
+
+    server_thread = Thread.new { @server.run }
+    sleep(0.1)
+
+    client = TCPSocket.new(@bind, @port)
+    client.puts "POST /test_filter HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhello"
+    response = client.read
+    client.close
+
+    assert_match(/hello/, response)
+
+    @server.close
+    server_thread.join
+  end
 end


### PR DESCRIPTION
- In this commit were identified and possibly fixed the issue of thread starvation. When the client close connection abruptly, an error were being raised in the ensure clause that closed the connection, since it was already terminated. This was fixed and, to prevent other sources of thread starvation, a mechanism to maintain the threads in the pool was created.