### PR TITLE
Properly handling server shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,5 +71,6 @@
 ## [1.1.0] - 2023-xx-xx
 
 - Adding support for other SSL/TSL keys other than RSA
+- New mechanism to handle server shutdown properly
 - Improving log readability
 - Automatic logging is now optional


### PR DESCRIPTION
- In order to wait for running threads to finish their tasks before shutting down
and not accept more requests in the meantime,
a shutdown method was included in the server
along with modifications to the method that
maintain threads.