### PR TITLE
Implementing Cron Job feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,13 @@
 
 - Fixing critical bug where threads were being killed and not respawning after abrupt client connection shutdown
 
-## [1.1.0] - 2023-xx-xx
+## [1.1.0] - 2023-05-20
 
 - Adding support for other SSL/TSL keys other than RSA
 - New mechanism to handle server shutdown properly
 - Improving log readability
 - Automatic logging is now optional
+
+## [1.1.1] - 2023-xx-xx
+
+- Adding native cron jobs

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ MacawFramework is a lightweight, easy-to-use web framework for Ruby designed to 
 medium-sized web applications. With support for various HTTP methods, caching, and session management, MacawFramework 
 provides developers with the essential tools to quickly build and deploy their applications.
 
+- [MacawFramework](#macawframework)
+    * [Features](#features)
+    * [Installation](#installation)
+    * [Usage](#usage)
+        + [Basic routing: Define routes with support for GET, POST, PUT, PATCH, and DELETE HTTP methods](#basic-routing-define-routes-with-support-for-get-post-put-patch-and-delete-http-methods)
+        + [Caching: Improve performance by caching responses and configuring cache invalidation](#caching-improve-performance-by-caching-responses-and-configuring-cache-invalidation)
+        + [Session management: Handle user sessions securely with server-side in-memory storage](#session-management-handle-user-sessions-securely-with-server-side-in-memory-storage)
+        + [Configuration: Customize various aspects of the framework through the application.json configuration file, such as rate limiting, SSL support, and Prometheus integration](#configuration-customize-various-aspects-of-the-framework-through-the-applicationjson-configuration-file-such-as-rate-limiting-ssl-support-and-prometheus-integration)
+        + [Monitoring: Easily monitor your application performance and metrics with built-in Prometheus support](#monitoring-easily-monitor-your-application-performance-and-metrics-with-built-in-prometheus-support)
+        + [Cron Jobs](#cron-jobs)
+        + [Tips](#tips)
+    * [Contributing](#contributing)
+    * [License](#license)
+    * [Code of Conduct](#code-of-conduct)
+
 ## Features
 
 - Simple routing with support for GET, POST, PUT, PATCH, and DELETE HTTP methods
@@ -122,6 +137,24 @@ end
 curl http://localhost:8080/metrics
 ```
 
+### Cron Jobs
+
+Macaw Framework supports the declaration of cron jobs right in your application code. This feature allows developers to 
+define tasks that run at set intervals, starting after an optional delay. Each job runs in a separate thread, meaning 
+your cron jobs can execute in parallel without blocking the rest of your application.
+
+Here's an example of how to declare a cron job:
+
+```ruby
+m.setup_job(interval: 5, start_delay: 5, job_name: "cron job 1") do
+  puts "i'm a cron job that runs every 5 secs!"
+end
+```
+
+Values for interval and start_delay are in seconds.
+
+Caution: Defining a lot of jobs with low interval can severely degrade performance.
+
 ### Tips
 
 The automatic logging and log aspect are now optional. To disable them, simply start Macaw with `custom_log` set to nil.
@@ -159,6 +192,9 @@ is configurable via the `application.json` file.
 The verb methods must always return a string or nil (used as the response), a number corresponding to the HTTP status 
 code to be returned to the client and the response headers as a Hash or nil. If an endpoint doesn't return a value or 
 returns nil for body, status code and headers, a default 200 OK status will be sent as the response.
+
+For cron jobs without a start_delay, a value of 0 will be used. For a job without name, a unique name will be generated 
+for it.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,9 @@
 We are committed to addressing security issues in a timely manner. The following versions of MacawFramework are currently supported with security updates:
 
 | Version | Supported          |
-| ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
-| < 1.x   | :x:                |
+|---------| ------------------ |
+| 1.x.x   | :white_check_mark: |
+| < 1.0   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -24,4 +24,3 @@ Alternatively, you can send an email to aria.diniz.dev@gmail.com with the same i
 4. Once the issue is resolved, we will release a new version of MacawFramework with the necessary security fixes.
 
 Please remember to follow the project's [Code of Conduct](https://github.com/ariasdiniz/macaw_framework/blob/main/CODE_OF_CONDUCT.md) when reporting security vulnerabilities.
-

--- a/lib/macaw_framework/core/cron_runner.rb
+++ b/lib/macaw_framework/core/cron_runner.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+##
+# This module is responsible to set up a new thread
+# for each cron job defined
+class CronRunner
+  def initialize(macaw)
+    @logger = macaw.macaw_log
+    @macaw = macaw
+  end
+
+  ##
+  # Will start a thread for the defined cron job
+  # @param {Integer} interval
+  # @param {Integer?} start_delay
+  # @param {String} job_name
+  # @param {Proc} block
+  def start_cron_job_thread(interval, start_delay, job_name, &block)
+    raise "interval can't be <= 0 and start_delay can't be < 0!" if interval <= 0 || start_delay.negative?
+
+    @logger&.info("Starting thread for job #{job_name}")
+    start_delay ||= 0
+    thread = Thread.new do
+      name = job_name
+      interval_thread = interval
+      unless start_delay.nil?
+        @logger&.info("Job #{name} scheduled with delay. Will start running in #{start_delay} seconds.")
+        sleep(start_delay)
+      end
+
+      loop do
+        start_time = Time.now
+        @logger&.info("Running job #{name}")
+        block.call
+        @logger&.info("Job #{name} executed with success. New execution in #{interval_thread} seconds.")
+
+        execution_time = Time.now - start_time
+        sleep_time = [interval_thread - execution_time, 0].max
+        sleep(sleep_time)
+      rescue StandardError => e
+        @logger&.error("Error executing cron job with name #{name}: #{e.message}")
+      end
+    end
+    sleep(1)
+    @logger&.info("Thread for job #{job_name} started")
+    thread
+  end
+end

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/sig/cron_runner.rbs
+++ b/sig/cron_runner.rbs
@@ -1,0 +1,6 @@
+class CronRunner
+  @logger: Logger?
+  @macaw: MacawFramework::Macaw
+
+  def start_cron_job_thread: -> Thread
+end

--- a/sig/macaw_framework/macaw.rbs
+++ b/sig/macaw_framework/macaw.rbs
@@ -14,6 +14,7 @@ module MacawFramework
 
     attr_reader bind: String
     attr_reader config: Hash[String, untyped]
+    attr_reader jobs: Array[String]
     attr_reader macaw_log: Logger?
     attr_reader port: Integer
     attr_reader routes: Array[String]

--- a/test/test_cron_runner.rb
+++ b/test/test_cron_runner.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "../lib/macaw_framework/core/cron_runner"
+
+class TestCronRunner < Minitest::Test
+  class MockMacaw
+    attr_accessor :macaw_log
+  end
+
+  class MockLog
+    attr_reader :count
+
+    def initialize
+      @count = []
+    end
+
+    def info(_msg); end
+
+    def error(msg)
+      @count << msg
+    end
+  end
+
+  def test_start_cron_job_thread
+    macaw = MockMacaw.new
+    macaw.macaw_log = nil
+    msg_array = []
+
+    cron_runner = CronRunner.new(macaw)
+    cron_runner.start_cron_job_thread(1, 1, "TestJob") do
+      msg_array << "Job executed"
+    end
+    sleep(3)
+
+    assert_includes msg_array, "Job executed"
+  end
+
+  def test_error_handling
+    macaw = MockMacaw.new
+    macaw.macaw_log = MockLog.new
+
+    cron_runner = CronRunner.new(macaw)
+    thread = cron_runner.start_cron_job_thread(1, 0, "ErrorJob") { raise "Test error" }
+    sleep(3)
+
+    assert_includes macaw.macaw_log.count, "Error executing cron job with name ErrorJob: Test error"
+    thread.kill
+  end
+
+  def test_interval_and_start_delay_validation
+    macaw = MockMacaw.new
+    macaw.macaw_log = nil
+
+    cron_runner = CronRunner.new(macaw)
+
+    assert_raises(RuntimeError) { cron_runner.start_cron_job_thread(-1, 1, "NegativeIntervalJob") {} }
+    assert_raises(RuntimeError) { cron_runner.start_cron_job_thread(1, -1, "NegativeStartDelayJob") {} }
+    assert_raises(RuntimeError) { cron_runner.start_cron_job_thread(0, 1, "ZeroIntervalJob") {} }
+  end
+end


### PR DESCRIPTION
- In order to provide developers with the ability to schedule tasks without the need
of external tools, a simple cron job feature
was implemented. The feature spawns a new
thread for each job defined, and these
threads run in parallel with the server
thread pool; They do not consume the server's
threads.

- Caution: Defining a lot of jobs with low interval can severely degrade performance.