### PR TITLE
Fix/cron job bug (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,9 @@
 
 - Adding native cron jobs
 - Documentation improvement
+
+## [1.1.2] - 2023-05-31
+
+- Fixing retry bug in cron jobs, where retries were made after an exception without waiting for interval
+- Fixing another bug in cron jobs where an exception were thrown when start_delay were not set
+- Documentation improvement

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -56,7 +56,11 @@ module MacawFramework
     # with the respective path.
     # @param {String} path
     # @param {Proc} block
-    # @return {Integer, String}
+    # @example
+    # macaw = MacawFramework::Macaw.new
+    # macaw.get("/hello") do |context|
+    #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
+    # end
     def get(path, cache: false, &block)
       map_new_endpoint("get", cache, path, &block)
     end
@@ -67,7 +71,10 @@ module MacawFramework
     # @param {String} path
     # @param {Boolean} cache
     # @param {Proc} block
-    # @return {String, Integer}
+    # macaw = MacawFramework::Macaw.new
+    # macaw.post("/hello") do |context|
+    #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
+    # end
     def post(path, cache: false, &block)
       map_new_endpoint("post", cache, path, &block)
     end
@@ -77,7 +84,10 @@ module MacawFramework
     # with the respective path.
     # @param {String} path
     # @param {Proc} block
-    # @return {String, Integer}
+    # macaw = MacawFramework::Macaw.new
+    # macaw.put("/hello") do |context|
+    #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
+    # end
     def put(path, cache: false, &block)
       map_new_endpoint("put", cache, path, &block)
     end
@@ -87,7 +97,10 @@ module MacawFramework
     # with the respective path.
     # @param {String} path
     # @param {Proc} block
-    # @return {String, Integer}
+    # macaw = MacawFramework::Macaw.new
+    # macaw.patch("/hello") do |context|
+    #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
+    # end
     def patch(path, cache: false, &block)
       map_new_endpoint("patch", cache, path, &block)
     end
@@ -97,7 +110,10 @@ module MacawFramework
     # with the respective path.
     # @param {String} path
     # @param {Proc} block
-    # @return {String, Integer}
+    # macaw = MacawFramework::Macaw.new
+    # macaw.delete("/hello") do |context|
+    #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
+    # end
     def delete(path, cache: false, &block)
       map_new_endpoint("delete", cache, path, &block)
     end
@@ -108,7 +124,12 @@ module MacawFramework
     # @param {Integer?} start_delay
     # @param {String} job_name
     # @param {Proc} block
-    def setup_job(interval: 60, start_delay: nil, job_name: "job_#{SecureRandom.uuid}", &block)
+    # @example
+    # macaw = MacawFramework::Macaw.new
+    # macaw.setup_job(interval: 60, start_delay: 60, job_name: "job 1") do
+    #   puts "I'm a cron job that runs every minute"
+    # end
+    def setup_job(interval: 60, start_delay: 0, job_name: "job_#{SecureRandom.uuid}", &block)
       @cron_runner ||= CronRunner.new(self)
       @jobs ||= []
       @cron_runner.start_cron_job_thread(interval, start_delay, job_name, &block)

--- a/lib/macaw_framework/core/cron_runner.rb
+++ b/lib/macaw_framework/core/cron_runner.rb
@@ -16,6 +16,7 @@ class CronRunner
   # @param {String} job_name
   # @param {Proc} block
   def start_cron_job_thread(interval, start_delay, job_name, &block)
+    start_delay ||= 0
     raise "interval can't be <= 0 and start_delay can't be < 0!" if interval <= 0 || start_delay.negative?
 
     @logger&.info("Starting thread for job #{job_name}")
@@ -39,6 +40,7 @@ class CronRunner
         sleep(sleep_time)
       rescue StandardError => e
         @logger&.error("Error executing cron job with name #{name}: #{e.message}")
+        sleep(interval)
       end
     end
     sleep(1)

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/sig/macaw_framework/macaw.rbs
+++ b/sig/macaw_framework/macaw.rbs
@@ -3,6 +3,7 @@ module MacawFramework
     @bind: String
     @cache: untyped
     @config: Hash[String, untyped]
+    @cron_runner: CronRunner
     @endpoints_to_cache: Array[String]
     @macaw_log: Logger?
 
@@ -30,6 +31,8 @@ module MacawFramework
     def post: -> nil
 
     def put: -> nil
+
+    def setup_job: -> nil
 
     def start!: -> nil
 

--- a/test/test_cron_runner.rb
+++ b/test/test_cron_runner.rb
@@ -58,4 +58,19 @@ class TestCronRunner < Minitest::Test
     assert_raises(RuntimeError) { cron_runner.start_cron_job_thread(1, -1, "NegativeStartDelayJob") {} }
     assert_raises(RuntimeError) { cron_runner.start_cron_job_thread(0, 1, "ZeroIntervalJob") {} }
   end
+
+  def test_start_delay_default_to_zero
+    macaw = MockMacaw.new
+    macaw.macaw_log = nil
+    msg_array = []
+
+    cron_runner = CronRunner.new(macaw)
+    cron_runner.start_cron_job_thread(1, nil, "DefaultStartDelayJob") do
+      msg_array << "Job executed with default start delay"
+    end
+    sleep(2)
+
+    assert_includes msg_array, "Job executed with default start delay",
+                    "Job should execute even if start_delay is not set"
+  end
 end


### PR DESCRIPTION
* Fixing bug with retry in Cron Jobs

- Fixing a bug where, every time a non caught exception was thrown in the cron job, it
instantaneously retried. Now it retry only
after the set interval.

- Fixing a bug where an exception were thrown when the start_delay variable were not set.
Now it sets to 0 when the value isn't provided.

- Improving documentation of the route methods and cron job method in the Macaw
class