### PR TITLE
Fixing bug of framework not starting on non-Unix machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,7 @@
 ## [1.1.6] - 2023-07-19
 
 - Creating support for public folder
+
+## [1.1.7] - 2023-08-12
+
+- Fixing a bug where the server would not start with the public folder feature enabled on non-Unix systems

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ MacawFramework allows you to serve static assets, such as CSS, JavaScript, image
 To enable this functionality, make sure the "public" folder is placed in the same directory as the main.rb file. 
 The "public" folder should contain any static assets required by your web application.
 
-To avoid issues, instantiate the Macaw using the `dir` proporty as following:
+To avoid issues, instantiate the Macaw using the `dir` property as following:
 
 ```ruby
 MacawFramework::Macaw.new(dir: __dir__)
@@ -184,6 +184,8 @@ MacawFramework::Macaw.new(dir: __dir__)
 By default, MacawFramework will automatically serve files from the "public" folder recursively when matching requests 
 are made. For example, if you have an image file named "logo.png" inside a "img" folder in the "public" folder, it will 
 be accessible at http://yourdomain.com/img/logo.png without any additional configuration.
+
+#### Caution: This is incompatible with most non-unix systems, such as Windows. If you are using a non-unix system, you will need to manually configure the "public" folder and use dir as nil to avoid problems.
 
 ### Cron Jobs
 

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -24,7 +24,7 @@ module MacawFramework
 
     ##
     # @param {Logger} custom_log
-    def initialize(custom_log: Logger.new($stdout), server: ThreadServer, dir: __dir__)
+    def initialize(custom_log: Logger.new($stdout), server: ThreadServer, dir: nil)
       begin
         @routes = []
         @macaw_log ||= custom_log
@@ -203,9 +203,13 @@ module MacawFramework
     end
 
     def get_files_public_folder(dir)
-      folder_path = Pathname.new(File.expand_path("public", dir))
-      file_paths = folder_path.glob("**/*").select(&:file?)
-      file_paths.map { |path| "public/#{path.relative_path_from(folder_path)}" }
+      if dir.nil?
+        []
+      else
+        folder_path = Pathname.new(File.expand_path("public", dir))
+        file_paths = folder_path.glob("**/*").select(&:file?)
+        file_paths.map { |path| "public/#{path.relative_path_from(folder_path)}" }
+      end
     end
 
     def create_endpoint_public_files(dir)

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "1.1.6"
+  VERSION = "1.1.7"
 end


### PR DESCRIPTION
- Since the new feature `public folder` relies on a system-dependent feature of Ruby, some systems were not able to run applications with MacawFramework. To fix this, we set the dir: property default to nil and
skipped the use of this function when the value of dir is nil. This way, users should be able to use
the public folder feature only if they want by setting manually the value of dir at instantiation.

- Closes #97 