### PR TITLE
fix: fixing accepting new requests during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,7 @@
 
 - Optimizing bug report template on GitHub
 - Optimizing return clause of the get_files_public_folder method
+
+## [1.2.0] - 2023-09-17
+
+- Fixing bug where the server would accept new connections during shutdown

--- a/lib/macaw_framework/core/thread_server.rb
+++ b/lib/macaw_framework/core/thread_server.rb
@@ -62,7 +62,7 @@ class ThreadServer
     end
 
     loop do
-      @work_queue << @server.accept
+      @work_queue << @server.accept unless @is_shutting_down
     rescue OpenSSL::SSL::SSLError => e
       @macaw_log&.error("SSL error: #{e.message}")
     rescue IOError, Errno::EBADF

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "1.1.8"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
This commits fixes a bug where, during graceful shutdown new connections would be accepted