### PR TITLE
Removing log filter from logging aspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@
 - Optimizing bug report template on GitHub
 - Optimizing return clause of the get_files_public_folder method
 
-## [1.2.0] - 2023-09-17
+## [1.2.0] - 2023-10-05
 
 - Fixing bug where the server would accept new connections during shutdown
+
+## [1.2.1] - 2023-11-06
+
+- Simplifying logging aspect for readability

--- a/lib/macaw_framework/aspects/logging_aspect.rb
+++ b/lib/macaw_framework/aspects/logging_aspect.rb
@@ -12,17 +12,12 @@ module LoggingAspect
     return super(*args) if logger.nil?
 
     endpoint_name = args[1].split(".")[1..].join("/")
-    logger.info(LogDataFilter.sanitize_for_logging(
-                  "Request received for #{endpoint_name} with arguments: #{args[2..]}"
-                ))
+    logger.info("Request received for [#{endpoint_name}] from [#{args[-1]}]")
 
     begin
       response = super(*args)
-      logger.info(LogDataFilter.sanitize_for_logging("Response for #{endpoint_name}: #{response}"))
     rescue StandardError => e
-      logger.error(
-        LogDataFilter.sanitize_for_logging("Error processing #{endpoint_name}: #{e.message}\n#{e.backtrace.join("\n")}")
-      )
+      logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       raise e
     end
 

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
This commits removes the usage of logging filter from the log aspect for two reasons: 

1. Performance improvement
2. Log readability. 

This also improves the error logs when an exception is thrown, offering more insight on the error.