### PR TITLE
Including accessors to programmatically change parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.7
+  SuggestExtensions: false
+  NewCops: disable
 
 Style/StringLiterals:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,3 +115,7 @@
 ## [1.2.1] - 2023-11-06
 
 - Simplifying logging aspect for readability
+
+## [1.2.2]
+
+- Including possibility of setting port, bind and threads programmatically

--- a/README.md
+++ b/README.md
@@ -137,12 +137,6 @@ end
     "port": 8080,
     "bind": "localhost",
     "threads": 200,
-    "log": {
-      "max_length": 1024,
-      "sensitive_fields": [
-        "password"
-      ]
-    },
     "cache": {
       "cache_invalidation": 3600,
       "ignore_headers": [
@@ -230,9 +224,22 @@ MacawFramework::Macaw.new(custom_log: nil)
 - URL parameters like `...endOfUrl?key1=value1&key2=value2` can be found in the `context[:params]`
 
 ```ruby
+m = MacawFramework::Macaw.new
+
 m.get('/test_params') do |context|
   context[:params]["key1"] # returns: value1
 end
+```
+
+- You can also set `port`, `bind` and `threads` programmatically as shown below. This will override values set in the
+`application.json` file
+
+```ruby
+m = MacawFramework::Macaw.new
+
+m.port = 3000
+m.bind = '0.0.0.0'
+m.threads = 300
 ```
 
 - The default number of virtual threads in the thread pool is 200.

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -20,7 +20,8 @@ module MacawFramework
   class Macaw
     ##
     # Array containing the routes defined in the application
-    attr_reader :routes, :port, :bind, :threads, :macaw_log, :config, :jobs
+    attr_reader :routes, :macaw_log, :config, :jobs
+    attr_accessor :port, :bind, :threads
 
     ##
     # @param {Logger} custom_log
@@ -49,7 +50,7 @@ module MacawFramework
       @endpoints_to_cache = []
       @prometheus ||= nil
       @prometheus_middleware ||= nil
-      @server = server.new(self, @endpoints_to_cache, @cache, @prometheus, @prometheus_middleware)
+      @server_class = server
     end
 
     ##
@@ -161,6 +162,7 @@ module MacawFramework
         @macaw_log.info("Number of threads: #{@threads}")
         @macaw_log.info("---------------------------------")
       end
+      @server = @server_class.new(self, @endpoints_to_cache, @cache, @prometheus, @prometheus_middleware)
       server_loop(@server)
     rescue Interrupt
       if @macaw_log.nil?

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/sig/macaw_framework/macaw.rbs
+++ b/sig/macaw_framework/macaw.rbs
@@ -9,18 +9,17 @@ module MacawFramework
 
     @prometheus: untyped
     @prometheus_middleware: untyped
-    @server: Server
+    @server: untyped
 
     @threads: Integer
 
-    attr_reader bind: String
+    attr_accessor bind: String
     attr_reader config: Hash[String, untyped]
     attr_reader jobs: Array[String]
     attr_reader macaw_log: Logger?
-    attr_reader port: Integer
+    attr_accessor port: Integer
     attr_reader routes: Array[String]
-
-    attr_reader threads: Integer
+    attr_accessor threads: Integer
 
     def delete: -> nil
 

--- a/test/test_macaw_framework.rb
+++ b/test/test_macaw_framework.rb
@@ -76,7 +76,7 @@ class TestMacawFramework < Minitest::Spec
     instance = MacawFramework::Macaw.new(custom_log: nil)
 
     Thread.new do
-      sleep(1)
+      sleep(3)
       Thread.main.raise Interrupt
     end
 


### PR DESCRIPTION
- This commit includes accessors for the parameters port, bind and threads. They can now be set in the code.