### PR TITLE
Fixing log message on declaration of endpoints

### DIFF
--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -198,7 +198,8 @@ module MacawFramework
     def map_new_endpoint(prefix, cache, path, &block)
       @endpoints_to_cache << "#{prefix}.#{RequestDataFiltering.sanitize_method_name(path)}" if cache
       path_clean = RequestDataFiltering.extract_path(path)
-      @macaw_log&.info("Defining #{prefix.upcase} endpoint at /#{path}")
+      slash = path[0] == "/" ? "" : "/"
+      @macaw_log&.info("Defining #{prefix.upcase} endpoint at #{slash}#{path}")
       define_singleton_method("#{prefix}.#{path_clean}", block || lambda {
         |context = { headers: {}, body: "", params: {} }|
       })


### PR DESCRIPTION
Before this fix, when you declare a new endpoint sinalizing a / as the first character, the log message would print // at the start of the name of the endpoint. Now this behavior is fixed. Now the logs will always print the endpoint name with a single / independent if it was declared with / or not.