### PR TITLE
Improving cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,3 +128,7 @@
 
 - Fixing small bug on lof during endpoint declaration
 - Disclosing security issue on session storage
+
+## [1.2.5]
+
+- Improvements to cache usability

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ m.start!
 ### Caching: Improve performance by caching responses and configuring cache invalidation
 
 ```ruby
-m.get('/cached_data', cache: true) do |context|
+m.get('/cached_data', cache: ["header_to_cache", "query_param_to_cache"]) do |context|
   # Retrieve data
 end
 ```
@@ -140,11 +140,7 @@ end
     "bind": "localhost",
     "threads": 200,
     "cache": {
-      "cache_invalidation": 3600,
-      "ignore_headers": [
-        "header-to-be-ignored-from-caching-strategy",
-        "another-header-to-be-ignored-from-caching-strategy"
-      ]
+      "cache_invalidation": 3600
     },
     "prometheus": {
       "endpoint": "/metrics"

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -19,7 +19,6 @@ module MacawFramework
   # Class responsible for creating endpoints and
   # starting the web server.
   class Macaw
-
     attr_reader :routes, :macaw_log, :config, :jobs, :cached_methods
     attr_accessor :port, :bind, :threads
 

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -19,16 +19,19 @@ module MacawFramework
   # Class responsible for creating endpoints and
   # starting the web server.
   class Macaw
-    ##
-    # Array containing the routes defined in the application
-    attr_reader :routes, :macaw_log, :config, :jobs
+
+    attr_reader :routes, :macaw_log, :config, :jobs, :cached_methods
     attr_accessor :port, :bind, :threads
 
     ##
+    # Initialize Macaw Class
     # @param {Logger} custom_log
+    # @param {ThreadServer} server
+    # @param {String?} dir
     def initialize(custom_log: Logger.new($stdout), server: ThreadServer, dir: nil)
       begin
         @routes = []
+        @cached_methods = {}
         @macaw_log ||= custom_log
         @config = JSON.parse(File.read("application.json"))
         @port = @config["macaw"]["port"] || 8080
@@ -65,7 +68,7 @@ module MacawFramework
     # macaw.get("/hello") do |context|
     #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
     # end
-    def get(path, cache: false, &block)
+    def get(path, cache: [], &block)
       map_new_endpoint("get", cache, path, &block)
     end
 
@@ -81,7 +84,7 @@ module MacawFramework
     # macaw.post("/hello") do |context|
     #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
     # end
-    def post(path, cache: false, &block)
+    def post(path, cache: [], &block)
       map_new_endpoint("post", cache, path, &block)
     end
 
@@ -96,7 +99,7 @@ module MacawFramework
     # macaw.put("/hello") do |context|
     #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
     # end
-    def put(path, cache: false, &block)
+    def put(path, cache: [], &block)
       map_new_endpoint("put", cache, path, &block)
     end
 
@@ -111,7 +114,7 @@ module MacawFramework
     # macaw.patch("/hello") do |context|
     #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
     # end
-    def patch(path, cache: false, &block)
+    def patch(path, cache: [], &block)
       map_new_endpoint("patch", cache, path, &block)
     end
 
@@ -126,7 +129,7 @@ module MacawFramework
     # macaw.delete("/hello") do |context|
     #   return "Hello World!", 200, { "Content-Type" => "text/plain" }
     # end
-    def delete(path, cache: false, &block)
+    def delete(path, cache: [], &block)
       map_new_endpoint("delete", cache, path, &block)
     end
 
@@ -196,7 +199,8 @@ module MacawFramework
     end
 
     def map_new_endpoint(prefix, cache, path, &block)
-      @endpoints_to_cache << "#{prefix}.#{RequestDataFiltering.sanitize_method_name(path)}" if cache
+      @endpoints_to_cache << "#{prefix}.#{RequestDataFiltering.sanitize_method_name(path)}" unless cache.empty?
+      @cached_methods["#{prefix}.#{RequestDataFiltering.sanitize_method_name(path)}"] = cache unless cache.empty?
       path_clean = RequestDataFiltering.extract_path(path)
       slash = path[0] == "/" ? "" : "/"
       @macaw_log&.info("Defining #{prefix.upcase} endpoint at #{slash}#{path}")

--- a/lib/macaw_framework/aspects/cache_aspect.rb
+++ b/lib/macaw_framework/aspects/cache_aspect.rb
@@ -6,7 +6,7 @@ module CacheAspect
   def call_endpoint(cache, *args)
     return super(*args) unless !cache[:cache].nil? && cache[:endpoints_to_cache]&.include?(args[0])
 
-    cache_filtered_name = cache_name_filter(args[1], cache[:ignored_headers])
+    cache_filtered_name = cache_name_filter(args[1], cache[:cached_methods][args[0]])
 
     cache[:cache].mutex.synchronize do
       return cache[:cache].cache[cache_filtered_name][0] unless cache[:cache].cache[cache_filtered_name].nil?
@@ -19,9 +19,10 @@ module CacheAspect
 
   private
 
-  def cache_name_filter(client_data, ignored_headers)
-    filtered_headers = client_data[:headers].filter { |key, _value| !ignored_headers&.include?(key) }
-    [{ body: client_data[:body], params: client_data[:params], headers: filtered_headers }].to_s.to_sym
+  def cache_name_filter(client_data, cached_methods_params)
+    filtered_headers = client_data[:headers]&.filter { |key, _value| cached_methods_params&.include?(key) }
+    filtered_params = client_data[:params]&.filter { |key, _value| cached_methods_params&.include?(key) }
+    [{ params: filtered_params, headers: filtered_headers }].to_s.to_sym
   end
 
   def should_cache_response?(status)

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -83,12 +83,6 @@ module ServerBase
     )
   end
 
-  def set_cache_ignored_h
-    return unless @macaw.config&.dig("macaw", "cache", "ignore_headers")
-
-    @macaw.config["macaw"]["cache"]["ignore_headers"] || []
-  end
-
   def set_ssl
     ssl_config = @macaw.config["macaw"]["ssl"] if @macaw.config&.dig("macaw", "ssl")
     ssl_config ||= nil

--- a/lib/macaw_framework/core/thread_server.rb
+++ b/lib/macaw_framework/core/thread_server.rb
@@ -32,11 +32,13 @@ class ThreadServer
     @macaw_log = macaw.macaw_log
     @num_threads = macaw.threads
     @work_queue = Queue.new
-    ignored_headers = set_cache_ignored_h
     set_features
     @rate_limit ||= nil
-    ignored_headers ||= nil
-    @cache = { cache: cache, endpoints_to_cache: endpoints_to_cache || [], ignored_headers: ignored_headers }
+    @cache = {
+      cache: cache,
+      endpoints_to_cache: endpoints_to_cache || [],
+      cached_methods: macaw.cached_methods
+    }
     @prometheus = prometheus
     @prometheus_middleware = prometheus_mw
     @workers = []

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = "1.2.4"
+  VERSION = "1.2.5"
 end

--- a/sig/macaw_framework/macaw.rbs
+++ b/sig/macaw_framework/macaw.rbs
@@ -2,6 +2,7 @@ module MacawFramework
   class Macaw
     @bind: String
     @cache: untyped
+    @cached_methods: Hash[String, Array[String]]
     @config: Hash[String, untyped]
     @cron_runner: CronRunner
     @endpoints_to_cache: Array[String]

--- a/test/test_cache_aspect.rb
+++ b/test/test_cache_aspect.rb
@@ -43,9 +43,9 @@ class TestCacheAspect < Minitest::Test
     test_class = TestClass.new
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
-    cache.cache[:"[{:body=>\"a\", :params=>nil, :headers=>{\"a\"=>\"b\"}}]"] = ["Cached response", Time.now]
+    cache.cache[:"[{:params=>nil, :headers=>{\"a\"=>\"b\"}}]"] = ["Cached response", Time.now]
     response = test_class.call_endpoint(
-      { cache: cache, endpoints_to_cache: endpoints_to_cache, ignored_headers: [] },
+      { cache: cache, endpoints_to_cache: endpoints_to_cache, cached_methods: { "method1" => ["a"] } },
       "method1", { body: "a", params: nil, headers: { "a" => "b" } }
     )
 
@@ -57,14 +57,14 @@ class TestCacheAspect < Minitest::Test
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
     response = test_class.call_endpoint(
-      { cache: cache, endpoints_to_cache: endpoints_to_cache, ignored_headers: [] },
+      { cache: cache, endpoints_to_cache: endpoints_to_cache, cached_methods: { "method1" => ["a"] } },
       "method1", { body: "a", params: nil, headers: { "a" => "b" } }
     )
 
     assert_equal ["Original method response", 200, { "a" => "b" }], response
     assert_equal(
       ["Original method response", 200, { "a" => "b" }],
-      cache.cache[:"[{:body=>\"a\", :params=>nil, :headers=>{\"a\"=>\"b\"}}]"][0]
+      cache.cache[:"[{:params=>nil, :headers=>{\"a\"=>\"b\"}}]"][0]
     )
   end
 
@@ -73,14 +73,14 @@ class TestCacheAspect < Minitest::Test
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
     response = test_class.call_endpoint(
-      { cache: cache, endpoints_to_cache: endpoints_to_cache, ignored_headers: ["correlation-id"] },
+      { cache: cache, endpoints_to_cache: endpoints_to_cache, cached_methods: { "method1" => ["a"] } },
       "method1", { body: "a", params: nil, headers: { "a" => "b", "correlation-id" => "unique-id-1" } }
     )
 
     assert_equal ["Original method response", 200, { "a" => "b" }], response
     assert_equal(
       ["Original method response", 200, { "a" => "b" }],
-      cache.cache[:"[{:body=>\"a\", :params=>nil, :headers=>{\"a\"=>\"b\"}}]"][0]
+      cache.cache[:"[{:params=>nil, :headers=>{\"a\"=>\"b\"}}]"][0]
     )
   end
 
@@ -88,9 +88,9 @@ class TestCacheAspect < Minitest::Test
     test_class = TestClass.new
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
-    cache.cache[:"[{:body=>\"a\", :params=>nil, :headers=>{\"a\"=>\"b\"}}]"] = ["Cached response", Time.now]
+    cache.cache[:"[{:params=>nil, :headers=>{\"a\"=>\"b\"}}]"] = ["Cached response", Time.now]
     response = test_class.call_endpoint(
-      { cache: cache, endpoints_to_cache: endpoints_to_cache, ignored_headers: ["correlation-id"] },
+      { cache: cache, endpoints_to_cache: endpoints_to_cache, cached_methods: { "method1" => ["a"] } },
       "method1", { body: "a", params: nil, headers: { "a" => "b", "correlation-id" => "unique-id-2" } }
     )
 
@@ -102,14 +102,14 @@ class TestCacheAspect < Minitest::Test
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
     response = test_class.call_endpoint(
-      { cache: cache, endpoints_to_cache: endpoints_to_cache, ignored_headers: [] },
+      { cache: cache, endpoints_to_cache: endpoints_to_cache, cached_methods: { "method1" => ["a"] } },
       "method1", { body: "a", params: nil, headers: { "a" => "b" }, status: 200 }
     )
 
     assert_equal ["Original method response", 200, { "a" => "b" }], response
     assert_equal(
       ["Original method response", 200, { "a" => "b" }],
-      cache.cache[:"[{:body=>\"a\", :params=>nil, :headers=>{\"a\"=>\"b\"}}]"][0]
+      cache.cache[:"[{:params=>nil, :headers=>{\"a\"=>\"b\"}}]"][0]
     )
   end
 
@@ -118,7 +118,7 @@ class TestCacheAspect < Minitest::Test
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
     response = test_class.call_endpoint(
-      { cache: cache, endpoints_to_cache: endpoints_to_cache, ignored_headers: [] },
+      { cache: cache, endpoints_to_cache: endpoints_to_cache, cached_methods: { "method1" => ["a"] } },
       "method1", { body: "a", params: nil, headers: { "a" => "b" }, status: 302 }
     )
 
@@ -131,7 +131,7 @@ class TestCacheAspect < Minitest::Test
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
     response = test_class.call_endpoint(
-      { cache: cache, endpoints_to_cache: endpoints_to_cache, ignored_headers: [] },
+      { cache: cache, endpoints_to_cache: endpoints_to_cache, cached_methods: { "method1" => ["a"] } },
       "method1", { body: "a", params: nil, headers: { "a" => "b" }, status: 404 }
     )
 
@@ -144,7 +144,7 @@ class TestCacheAspect < Minitest::Test
     cache = CacheMock.new
     endpoints_to_cache = ["method1"]
     response = test_class.call_endpoint(
-      { cache: cache, endpoints_to_cache: endpoints_to_cache, ignored_headers: [] },
+      { cache: cache, endpoints_to_cache: endpoints_to_cache, cached_methods: { "method1" => ["a"] } },
       "method1", { body: "a", params: nil, headers: { "a" => "b" }, status: 500 }
     )
 

--- a/test/test_macaw_framework.rb
+++ b/test/test_macaw_framework.rb
@@ -49,7 +49,7 @@ class TestMacawFramework < Minitest::Spec
 
   def test_endpoint_cache_configuration
     macaw = MacawFramework::Macaw.new(custom_log: nil)
-    macaw.get("/cache_test", cache: true) {}
+    macaw.get("/cache_test", cache: ["test"]) {}
     assert_includes macaw.instance_variable_get(:@endpoints_to_cache), "get.cache_test"
   end
 

--- a/test/test_thread_server.rb
+++ b/test/test_thread_server.rb
@@ -12,7 +12,7 @@ require_relative "../lib/macaw_framework/errors/endpoint_not_mapped_error"
 require_relative "../lib/macaw_framework/errors/too_many_requests_error"
 
 class TestEndpoint
-  attr_reader :routes, :port, :bind, :threads, :macaw_log
+  attr_reader :routes, :port, :bind, :threads, :macaw_log, :cached_methods
   attr_accessor :config
 
   def initialize
@@ -22,6 +22,7 @@ class TestEndpoint
     @threads = 1
     @macaw_log = nil
     @config = nil
+    @cached_methods = []
     define_singleton_method("get.hello", ->(_context) { "Hello, World!" })
     define_singleton_method("get.ok", ->(_context) { ["Ok", 200] })
     define_singleton_method("get.ise", ->(_context) { raise StandardError, "Internal server error" })


### PR DESCRIPTION
- In order to make cache easier to use and reduce problems
with the old  configuration on the
application.json file, now instead of signalizing in the
file which headers and query parameters to not use, the
user will signalize which headers and parameters they
want to use cache during endpoint declaration.