### PR TITLE
improving code and adding cache class

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.3.1'
-          - '3.2.4'
-          - '2.7.0'
+          - '3.3.4'
+          - '3.2.5'
+          - '3.1.0'
 
     steps:
     - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
   NewCops: disable
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,9 @@ Metrics/PerceivedComplexity:
 
 Metrics/ClassLength:
   Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,3 +143,7 @@
 - Fixed a bug where errors were being logged with level INFO
 - Improved error stack trace
 
+## [1.3.1]
+- Fixing bug where missing session configuration on `application.json` break the application
+- Including a Cache module for manual caching.
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We evaluated MacawFramework (Version 1.2.0) to assess its ability to handle simu
 
 MacawFramework is built to be highly compatible, since it uses only native Ruby code:
 
-- **MRI**: MacawFramework is compatible with Matz's Ruby Interpreter (MRI), version 2.7.0 and onwards. If you are using this version or a more recent one, you should not encounter any compatibility issues.
+- **MRI**: MacawFramework is compatible with Matz's Ruby Interpreter (MRI), version 3.0.0 and onwards. If you are using this version or a more recent one, you should not encounter any compatibility issues.
 
 - **TruffleRuby**: TruffleRuby is another Ruby interpreter that is fully compatible with MacawFramework. This provides developers with more flexibility in their choice of Ruby interpreter.
 
@@ -112,6 +112,17 @@ end
 ```
 
 *Observation: To activate caching, you also have to set its properties in the `application.json` file. If you don't, the caching strategy will not work. See the Configuration section below for more details.*
+
+Another method of cache is the manual cache via the `MacawFramework::Cache` class. You can manually
+call the `read` and `write` methods of this singleton to save and recover values inside your methods.
+
+```ruby
+MacawFramework::Cache.write(:name, 'Maria', expires_in: 1800)
+# Your code
+MacawFramework::Cache.read(:name) # Maria
+```
+
+Manual cache does not need any additional configuration.
 
 ### Session management: Handle user sessions with server-side in-memory storage
 

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -260,6 +260,9 @@ module MacawFramework
     end
   end
 
+  ##
+  # This singleton class allows to manually cache
+  # parameters and other data.
   class Cache
     include Singleton
 

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -268,6 +268,30 @@ module MacawFramework
 
     attr_accessor :invalidation_frequency
 
+    ##
+    # Write a value to Cache memory.
+    # Can be called statically or from an instance.
+    # @param {String} tag
+    # @param {Object} value
+    # @param {Integer} expires_in Defaults to 3600.
+    # @return nil
+    #
+    # @example
+    #   MacawFramework::Cache.write("name", "Maria", expires_in: 7200)
+    def self.write(tag, value, expires_in: 3600)
+      MacawFramework::Cache.instance.write(tag, value, expires_in: expires_in)
+    end
+
+    ##
+    # Write a value to Cache memory.
+    # Can be called statically or from an instance.
+    # @param {String} tag
+    # @param {Object} value
+    # @param {Integer} expires_in Defaults to 3600.
+    # @return nil
+    #
+    # @example
+    #   MacawFramework::Cache.write("name", "Maria", expires_in: 7200)
     def write(tag, value, expires_in: 3600)
       if read(tag).nil?
         @mutex.synchronize do
@@ -279,6 +303,24 @@ module MacawFramework
       end
     end
 
+    ##
+    # Read the value with the specified tag.
+    # Can be called statically or from an instance.
+    # @param {String} tag
+    # @return {String|nil}
+    #
+    # @example
+    #   MacawFramework::Cache.read("name") # Maria
+    def self.read(tag) = MacawFramework::Cache.instance.read(tag)
+
+    ##
+    # Read the value with the specified tag.
+    # Can be called statically or from an instance.
+    # @param {String} tag
+    # @return {String|nil}
+    #
+    # @example
+    #   MacawFramework::Cache.read("name") # Maria
     def read(tag) = @cache.dig(tag, :value)
 
     private

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -115,6 +115,8 @@ module ServerBase
   end
 
   def set_session
+    return unless @macaw.session
+
     @session ||= {}
     inv = if @macaw.config&.dig('macaw', 'session', 'invalidation_time')
             MemoryInvalidationMiddleware.new(@macaw.config['macaw']['session']['invalidation_time'])
@@ -127,7 +129,7 @@ module ServerBase
   def set_features
     @is_shutting_down = false
     set_rate_limiting
-    set_session if @macaw.session
+    set_session
     set_ssl
   end
 end

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -29,7 +29,7 @@ module ServerBase
         headers: client_data[:headers],
         body: client_data[:body],
         params: client_data[:params],
-        client: @session[session_id][0]
+        client: @session&.dig(session_id)&.dig(0)
       }
     )
   end

--- a/lib/macaw_framework/data_filters/request_data_filtering.rb
+++ b/lib/macaw_framework/data_filters/request_data_filtering.rb
@@ -5,7 +5,7 @@ require_relative '../errors/endpoint_not_mapped_error'
 ##
 # Module containing methods to filter Strings
 module RequestDataFiltering
-  VARIABLE_PATTERN = %r{:[^/]+}.freeze
+  VARIABLE_PATTERN = %r{:[^/]+}
 
   ##
   # Method responsible for extracting information

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end

--- a/macaw_framework.gemspec
+++ b/macaw_framework.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 created for study purposes, now production-ready and open for contributions."
   spec.homepage = 'https://github.com/ariasdiniz/macaw_framework'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.metadata['documentation_uri'] = 'https://rubydoc.info/gems/macaw_framework'
   spec.metadata['homepage_uri'] = spec.homepage

--- a/test/test_cache_class.rb
+++ b/test/test_cache_class.rb
@@ -5,8 +5,8 @@ require_relative '../lib/macaw_framework'
 
 class TestCacheClass < Minitest::Test
   def setup
-    @cache = MacawFramework::Cache.instance
-    @cache.invalidation_frequency = 0.5
+    @cache = MacawFramework::Cache
+    @cache.instance.invalidation_frequency = 0.5
   end
 
   def test_cache_hit

--- a/test/test_cache_class.rb
+++ b/test/test_cache_class.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+require_relative '../lib/macaw_framework'
+
+class TestCacheClass < Minitest::Test
+  def setup
+    @cache = MacawFramework::Cache.instance
+    @cache.invalidation_frequency = 0.5
+  end
+
+  def test_cache_hit
+    @cache.write('foo', 'bar')
+    assert(@cache.read('foo') == 'bar')
+  end
+
+  def test_cache_miss
+    @cache.write('foo', 'bar')
+    assert(@cache.read('bar').nil?)
+  end
+
+  def test_invalidation
+    @cache.write('foo', 'bar', expires_in: 1)
+    assert(@cache.read('foo') == 'bar')
+    sleep(3)
+    assert(@cache.read('foo').nil?)
+  end
+
+  def test_not_yet_invalid
+    @cache.write('foo', 'bar', expires_in: 60)
+    assert(@cache.read('foo') == 'bar')
+    sleep(3)
+    assert(@cache.read('foo') == 'bar')
+  end
+end


### PR DESCRIPTION
This PR aims to add a new class `Cache` to manually cache parameters and other
data. I also improve the code of the main Macaw class. With these modifications
Macaw lose support to Ruby < 3.0.0.