### PR TITLE
fix: error processing request with empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,3 +147,7 @@
 - Fixing bug where missing session configuration on `application.json` break the application
 - Including a Cache module for manual caching.
 
+## [1.3.21]
+- Refactoring shutdown method
+- Fixing a bug where a HTTP call without client data broke the parser
+- Removing logs registering new HTTP connections to reduce log bloat

--- a/lib/macaw_framework/aspects/logging_aspect.rb
+++ b/lib/macaw_framework/aspects/logging_aspect.rb
@@ -11,9 +11,6 @@ module LoggingAspect
   def call_endpoint(logger, *args)
     return super(*args) if logger.nil?
 
-    endpoint_name = args[1].split('.')[1..].join('/')
-    logger.info("Request received for [#{endpoint_name}] from [#{args[-1]}]")
-
     begin
       response = super(*args)
     rescue StandardError => e

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -39,14 +39,13 @@ module ServerBase
   end
 
   def handle_client(client)
-    path, method_name, headers, body, parameters = RequestDataFiltering.parse_request_data(client, @macaw.routes)
+    _path, method_name, headers, body, parameters = RequestDataFiltering.parse_request_data(client, @macaw.routes)
     raise EndpointNotMappedError unless @macaw.respond_to?(method_name)
     raise TooManyRequestsError unless @rate_limit.nil? || @rate_limit.allow?(client.peeraddr[3])
 
     client_data = get_client_data(body, headers, parameters)
     session_id = declare_client_session(client_data[:headers], @macaw.secure_header) if @macaw.session
 
-    @macaw_log&.info("Running #{path.gsub("\n", '').gsub("\r", '')}")
     message, status, response_headers = call_endpoint(@prometheus_middleware, @macaw_log, @cache,
                                                       method_name, client_data, session_id, client.peeraddr[3])
     response_headers ||= {}

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = '1.3.2'
+  VERSION = '1.3.21'
 end


### PR DESCRIPTION
- This PR fixes an error where http requests with empty bodies and no carriage return/endline characters after the HTTP head caused the gsub method to break when parsing request data, reported on Issue #116 .

- It also removes new log register for every new connection to remove log bloat