### PR TITLE
fix: thread safety, header parsing, deadlock fixes and HTTP keep-alive support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         ruby:
           - '4.0.1'
-          - '3.4.2'
+          - '3.2'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         ruby:
           - '4.0.1'
-          - '3.2'
+          - '3.4.2'
 
     steps:
     - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   NewCops: disable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@
 ## [1.4.1] - 2026-02-01
 - Fixing issue when re-spawning new threads
 
-## [1.4.1] - 2026-02-24
+## [1.4.2] - 2026-02-24
 - Removing unused Rate Limiting Middleware
 
 ## [1.4.3] - 2026-03-04
@@ -184,3 +184,8 @@
 - Fix RFC 7230 non-compliance: remove stray space before `\r\n` in HTTP status line
 - Add eviction thread error rescue in `MemoryInvalidationMiddleware` to prevent silent thread death
 - Set `frozen_string_literal: true` consistently across all library files
+- Implement HTTP keep-alive: persistent TCP connections now reuse the same socket for multiple requests without a new handshake
+- Add configurable per-connection read timeout (default 30 s, configurable via `keep_alive_timeout` in `application.json`) to prevent idle or faulty clients from holding worker threads indefinitely
+- Server now responds with `Connection: keep-alive` or `Connection: close` headers according to the client's request
+- Fix request parser to properly detect client EOF and raise `EOFError` instead of propagating `nil` through the parsing pipeline
+- Use `IO#timeout=` (Ruby 3.2+) for socket timeout with `SO_RCVTIMEO` fallback for older Ruby and SSL sockets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,3 +163,24 @@
 
 ## [1.4.1] - 2026-02-24
 - Removing unused Rate Limiting Middleware
+
+## [1.4.3] - 2026-03-04
+- Fix critical bug in `sanitize_parameter_value` where the first `gsub` result was discarded, leaving special characters unsanitized
+- Fix header parsing regex to correctly accept real-world headers (Authorization, Cookie, User-Agent, Host with port, etc.)
+- Fix deadlock in `maintain_worker_pool` caused by non-reentrant mutex re-acquisition when respawning dead workers
+- Add missing `require 'digest'` in `LogDataFilter`, preventing `NameError` when sensitive fields are configured
+- Fix thread-safety in `Cache#write` and `Cache#read`: both now always synchronize on the internal mutex
+- Fix thread-safety of `@session` hash: `declare_client_session` now synchronizes on a dedicated mutex
+- Fix `**kwargs` being silently dropped in `LoggingAspect` and `PrometheusAspect` when forwarding to `super`
+- Fix `CacheAspect` holding mutex during entire endpoint execution on cache miss; endpoint now runs outside the lock
+- Remove blocking `sleep(2)` from `MemoryInvalidationMiddleware` constructor; eviction thread no longer halts server startup
+- Remove `sleep(1)` per cron job from `CronRunner#start_cron_job_thread`; startup is no longer O(N) seconds
+- Remove dead code in `CronRunner`: duplicate `start_delay ||= 0` and always-true `unless start_delay.nil?` guard
+- Make `application.json` path configurable via `MACAW_CONFIG` env var; rescue `Errno::ENOENT` and `JSON::ParserError` with graceful fallback
+- Remove broken SSL2 and SSL3 from `SupportedSSLVersions` (POODLE/DROWN, unavailable on modern OpenSSL)
+- `LoggingAspect` now logs request params, body, and response status on every endpoint call
+- Use `Process.clock_gettime(Process::CLOCK_MONOTONIC)` in `PrometheusAspect` instead of `Time.now` for accurate duration measurement
+- Fix Prometheus `/metrics` endpoint `Content-Type` to `text/plain; version=0.0.4; charset=utf-8`
+- Fix RFC 7230 non-compliance: remove stray space before `\r\n` in HTTP status line
+- Add eviction thread error rescue in `MemoryInvalidationMiddleware` to prevent silent thread death
+- Set `frozen_string_literal: true` consistently across all library files

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ end
       "endpoint": "/metrics"
     },
     "ssl": {
-      "min": "SSL3",
+      "min": "TSL1.3",
       "max": "TLS1.3",
       "key_type": "EC",
       "cert_file_name": "path/to/cert/file/file.crt",

--- a/lib/macaw_framework/aspects/cache_aspect.rb
+++ b/lib/macaw_framework/aspects/cache_aspect.rb
@@ -4,17 +4,21 @@
 # Aspect that provide cache for the endpoints.
 module CacheAspect
   def call_endpoint(cache, *args, **kwargs)
-    return super(*args, **kwargs) unless !cache[:cache].nil? && cache[:endpoints_to_cache]&.include?(args[0])
+    return super(*args, **kwargs) if cache[:cache].nil? || !cache[:endpoints_to_cache]&.include?(args[0])
 
     cache_filtered_name = cache_name_filter(args[1], cache[:cached_methods][args[0]])
 
-    cache[:cache].mutex.synchronize do
-      return cache[:cache].cache[cache_filtered_name][0] unless cache[:cache].cache[cache_filtered_name].nil?
+    # Check cache first without holding the lock during endpoint execution
+    cached_response = cache[:cache].mutex.synchronize { cache[:cache].cache[cache_filtered_name]&.dig(0) }
+    return cached_response unless cached_response.nil?
 
-      response = super(*args, **kwargs)
-      cache[:cache].cache[cache_filtered_name] = [response, Time.now] if should_cache_response?(response[1])
-      response
+    response = super(*args, **kwargs)
+    if should_cache_response?(response[1])
+      cache[:cache].mutex.synchronize do
+        cache[:cache].cache[cache_filtered_name] = [response, Time.now]
+      end
     end
+    response
   end
 
   private

--- a/lib/macaw_framework/aspects/cache_aspect.rb
+++ b/lib/macaw_framework/aspects/cache_aspect.rb
@@ -8,7 +8,6 @@ module CacheAspect
 
     cache_filtered_name = cache_name_filter(args[1], cache[:cached_methods][args[0]])
 
-    # Check cache first without holding the lock during endpoint execution
     cached_response = cache[:cache].mutex.synchronize { cache[:cache].cache[cache_filtered_name]&.dig(0) }
     return cached_response unless cached_response.nil?
 

--- a/lib/macaw_framework/aspects/logging_aspect.rb
+++ b/lib/macaw_framework/aspects/logging_aspect.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'logger'
 require_relative '../data_filters/log_data_filter'
@@ -11,12 +11,21 @@ module LoggingAspect
   def call_endpoint(logger, *args, **kwargs)
     return super(*args, **kwargs) if logger.nil?
 
+    endpoint_name = args[1]
+    client_data   = args[2]
+
+    logger.info("Calling endpoint: #{endpoint_name} | " \
+                "params: #{LogDataFilter.sanitize_for_logging(client_data[:params].to_s)} | " \
+                "body: #{LogDataFilter.sanitize_for_logging(client_data[:body])}")
+
     begin
-      response = super(*args)
+      response = super(*args, **kwargs)
     rescue StandardError => e
       logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       raise e
     end
+
+    logger.info("Response from endpoint: #{endpoint_name} | status: #{response&.dig(1)}")
 
     response
   end

--- a/lib/macaw_framework/aspects/prometheus_aspect.rb
+++ b/lib/macaw_framework/aspects/prometheus_aspect.rb
@@ -6,12 +6,12 @@ module PrometheusAspect
   def call_endpoint(prometheus_middleware, *args, **kwargs)
     return super(*args, **kwargs) if prometheus_middleware.nil?
 
-    start_time = Time.now
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     begin
-      response = super(*args)
+      response = super(*args, **kwargs)
     ensure
-      duration = (Time.now - start_time) * 1_000
+      duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1_000
 
       endpoint_name = args[2].split('.').join('/')
 

--- a/lib/macaw_framework/cache.rb
+++ b/lib/macaw_framework/cache.rb
@@ -37,13 +37,8 @@ class MacawFramework::Cache
   # @example
   #   MacawFramework::Cache.write("name", "Maria", expires_in: 7200)
   def write(tag, value, expires_in: 3600)
-    if read(tag).nil?
-      @mutex.synchronize do
-        @cache.store(tag, { value: value, expires_in: Time.now + expires_in })
-      end
-    else
-      @cache[tag][:value] = value
-      @cache[tag][:expires_in] = Time.now + expires_in
+    @mutex.synchronize do
+      @cache.store(tag, { value: value, expires_in: Time.now + expires_in })
     end
   end
 
@@ -65,7 +60,9 @@ class MacawFramework::Cache
   #
   # @example
   #   MacawFramework::Cache.read("name") # Maria
-  def read(tag) = @cache.dig(tag, :value)
+  def read(tag)
+    @mutex.synchronize { @cache.dig(tag, :value) }
+  end
 
   private
 

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -37,33 +37,58 @@ module ServerBase
   end
 
   def handle_client(client)
-    _path, method_name, headers, body, parameters = RequestDataFiltering.parse_request_data(client, @macaw.routes)
-    raise EndpointNotMappedError unless @macaw.respond_to?(method_name)
+    apply_socket_timeout(client)
+    loop do
+      _path, method_name, headers, body, parameters = RequestDataFiltering.parse_request_data(client, @macaw.routes)
+      raise EndpointNotMappedError unless @macaw.respond_to?(method_name)
 
-    client_data = get_client_data(body, headers, parameters)
-    session_id = declare_client_session(client_data[:headers], @macaw.secure_header) if @macaw.session
-
-    message, status, response_headers = call_endpoint(@prometheus_middleware, @macaw_log, @cache,
-                                                      method_name, client_data, session_id, client.peeraddr[3])
-    response_headers ||= {}
-    response_headers[@macaw.secure_header] = session_id if @macaw.session
-    status ||= 200
-    message ||= nil
-    response_headers ||= nil
-    client.puts ResponseDataFilter.mount_response(status, response_headers, message)
-  rescue IOError, Errno::EPIPE => e
-    @macaw_log&.error("Error writing to client: #{e.message}")
-  rescue EndpointNotMappedError
-    client.print "HTTP/1.1 404 Not Found\r\n\r\n"
-  rescue StandardError => e
-    client.print "HTTP/1.1 500 Internal Server Error\r\n\r\n"
-    @macaw_log&.error(e.full_message)
+      keep_alive = keep_alive_connection?(headers)
+      client.write build_response(method_name, headers, body, parameters, keep_alive)
+      break unless keep_alive
+    rescue Errno::ECONNRESET, Errno::EPIPE, IOError
+      break
+    rescue EndpointNotMappedError
+      client.print "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n"
+      break
+    rescue StandardError => e
+      client.print "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\n\r\n"
+      @macaw_log&.error(e.full_message)
+      break
+    end
   ensure
     begin
       client.close
     rescue IOError => e
       @macaw_log&.error("Error closing client: #{e.message}")
     end
+  end
+
+  def build_response(method_name, headers, body, parameters, keep_alive)
+    client_data = get_client_data(body, headers, parameters)
+    session_id = declare_client_session(client_data[:headers], @macaw.secure_header) if @macaw.session
+
+    message, status, response_headers = call_endpoint(@prometheus_middleware, @macaw_log, @cache,
+                                                      method_name, client_data, session_id, nil)
+    response_headers ||= {}
+    response_headers[@macaw.secure_header] = session_id if @macaw.session
+    status ||= 200
+    response_headers['Connection'] = keep_alive ? 'keep-alive' : 'close'
+    ResponseDataFilter.mount_response(status, response_headers, message)
+  end
+
+  def apply_socket_timeout(client)
+    timeout = @macaw.keep_alive_timeout || 30
+    client.timeout = timeout
+  rescue NoMethodError
+    io = client.respond_to?(:to_io) ? client.to_io : client
+    timeval = [timeout, 0].pack('l_2')
+    io.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVTIMEO, timeval)
+  rescue StandardError
+    nil
+  end
+
+  def keep_alive_connection?(headers)
+    headers['Connection']&.downcase != 'close'
   end
 
   def declare_client_session(headers, secure_header_name)

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -73,6 +73,7 @@ module ServerBase
     response_headers[@macaw.secure_header] = session_id if @macaw.session
     status ||= 200
     response_headers['Connection'] = keep_alive ? 'keep-alive' : 'close'
+    response_headers['Content-Length'] = message.to_s.bytesize
     ResponseDataFilter.mount_response(status, response_headers, message)
   end
 

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -67,10 +67,13 @@ module ServerBase
   end
 
   def declare_client_session(headers, secure_header_name)
-    session_id = headers[secure_header_name] || SecureRandom.uuid
-    session_id = SecureRandom.uuid if @session[session_id].nil?
-    @session[session_id] ||= [{}, Time.now]
-    session_id
+    @session_mutex ||= Mutex.new
+    @session_mutex.synchronize do
+      session_id = headers[secure_header_name] || SecureRandom.uuid
+      session_id = SecureRandom.uuid if @session[session_id].nil?
+      @session[session_id] ||= [{}, Time.now]
+      session_id
+    end
   end
 
   def set_ssl

--- a/lib/macaw_framework/core/cron_runner.rb
+++ b/lib/macaw_framework/core/cron_runner.rb
@@ -20,11 +20,11 @@ class CronRunner
     raise "interval can't be <= 0 and start_delay can't be < 0!" if interval <= 0 || start_delay.negative?
 
     @logger&.info("Starting thread for job #{job_name}")
-    start_delay ||= 0
     thread = Thread.new do
       name = job_name
       interval_thread = interval
-      unless start_delay.nil?
+
+      if start_delay.positive?
         @logger&.info("Job #{name} scheduled with delay. Will start running in #{start_delay} seconds.")
         sleep(start_delay)
       end
@@ -40,10 +40,9 @@ class CronRunner
         sleep(sleep_time)
       rescue StandardError => e
         @logger&.error("Error executing cron job with name #{name}: #{e.message}")
-        sleep(interval)
+        sleep(interval_thread)
       end
     end
-    sleep(1)
     @logger&.info("Thread for job #{job_name} started")
     thread
   end

--- a/lib/macaw_framework/core/thread_server.rb
+++ b/lib/macaw_framework/core/thread_server.rb
@@ -83,24 +83,26 @@ class ThreadServer
 
     @num_threads.times { @work_queue << :shutdown }
     @workers.each(&:join)
-    @server.close
+    @server&.close
   end
 
   private
 
   def spawn_worker
-    @workers_mutex.synchronize do
-      t = Thread.new do
-        loop do
-          client = @work_queue.pop
-          break if client == :shutdown
+    @workers_mutex.synchronize { create_worker }
+  end
 
-          handle_client(client)
-        end
+  def create_worker
+    t = Thread.new do
+      loop do
+        client = @work_queue.pop
+        break if client == :shutdown
+
+        handle_client(client)
       end
-      @workers << t
-      t
     end
+    @workers << t
+    t
   end
 
   def maintain_worker_pool
@@ -112,7 +114,7 @@ class ThreadServer
           else
             @macaw_log&.error("Worker thread #{index} died, respawning...")
             @workers.delete_at(index)
-            spawn_worker
+            create_worker
           end
         end
       end

--- a/lib/macaw_framework/data_filters/log_data_filter.rb
+++ b/lib/macaw_framework/data_filters/log_data_filter.rb
@@ -1,6 +1,7 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'json'
+require 'digest'
 
 ##
 # Module responsible for sanitizing log data

--- a/lib/macaw_framework/data_filters/request_data_filtering.rb
+++ b/lib/macaw_framework/data_filters/request_data_filtering.rb
@@ -11,7 +11,10 @@ module RequestDataFiltering
   # Method responsible for extracting information
   # provided by the client like Headers and Body
   def self.parse_request_data(client, routes)
-    path, parameters = extract_url_parameters(client.gets&.gsub('HTTP/1.1', ''))
+    first_line = client.gets
+    raise EOFError if first_line.nil?
+
+    path, parameters = extract_url_parameters(first_line.gsub('HTTP/1.1', ''))
     parameters = {} if parameters.nil?
 
     method_name = sanitize_method_name(path)

--- a/lib/macaw_framework/data_filters/request_data_filtering.rb
+++ b/lib/macaw_framework/data_filters/request_data_filtering.rb
@@ -74,8 +74,8 @@ module RequestDataFiltering
   def self.extract_headers(client)
     header = client.gets&.delete("\n")&.delete("\r")
     headers = {}
-    while header&.match(%r{[a-zA-Z0-9\-/*]*: [a-zA-Z0-9\-/*]})
-      split_header = header.split(':')
+    while header&.match(/\A[^:]+:\s*.+/)
+      split_header = header.split(':', 2)
       headers[split_header[0].strip] = split_header[1].strip
       header = client.gets&.delete("\n")&.delete("\r")
     end
@@ -115,7 +115,6 @@ module RequestDataFiltering
   ##
   # Method responsible for sanitizing the parameter value
   def self.sanitize_parameter_value(value)
-    value&.gsub(/[^\w\s]/, '')
-    value&.gsub(/\s/, '')
+    value&.gsub(/[^\w\s]/, '')&.gsub(/\s/, '')
   end
 end

--- a/lib/macaw_framework/data_filters/response_data_filter.rb
+++ b/lib/macaw_framework/data_filters/response_data_filter.rb
@@ -12,20 +12,19 @@ module ResponseDataFilter
   end
 
   def self.mount_first_response_line(status, headers)
-    separator = " \r\n\r\n"
-    separator = " \r\n" unless headers.nil?
-
-    "HTTP/1.1 #{status} #{HTTP_STATUS_CODE_MAP[status]}#{separator}"
+    reason = HTTP_STATUS_CODE_MAP[status] || 'Unknown'
+    separator = headers.nil? ? "\r\n\r\n" : "\r\n"
+    "HTTP/1.1 #{status} #{reason}#{separator}"
   end
 
   def self.mount_response_headers(headers)
     return '' if headers.nil?
 
-    response = ''
+    response = +''
     headers.each do |key, value|
-      response += "#{key}: #{value}\r\n"
+      response << "#{key}: #{value}\r\n"
     end
-    response += "\r\n"
+    response << "\r\n"
     response
   end
 end

--- a/lib/macaw_framework/macaw.rb
+++ b/lib/macaw_framework/macaw.rb
@@ -23,7 +23,7 @@ module MacawFramework; end
 # Class responsible for creating endpoints and
 # starting the web server.
 class MacawFramework::Macaw
-  attr_reader :routes, :macaw_log, :config, :jobs, :cached_methods, :secure_header, :session
+  attr_reader :routes, :macaw_log, :config, :jobs, :cached_methods, :secure_header, :session, :keep_alive_timeout
   attr_accessor :port, :bind, :threads
 
   ##
@@ -223,12 +223,15 @@ class MacawFramework::Macaw
     @port = @config['macaw']['port'] || 8080
     @bind = @config['macaw']['bind'] || 'localhost'
     @threads = @config['macaw']['threads'] || 200
+    @keep_alive_timeout = @config['macaw']['keep_alive_timeout'] || 30
   rescue Errno::ENOENT
     @macaw_log&.warn("Config file '#{config_file}' not found, using default settings.")
     @config = { 'macaw' => {} }
+    @keep_alive_timeout = 30
   rescue JSON::ParserError => e
     @macaw_log&.warn("Config file '#{config_file}' is not valid JSON: #{e.message}. Using default settings.")
     @config = { 'macaw' => {} }
+    @keep_alive_timeout = 30
   end
 
   def setup_prometheus

--- a/lib/macaw_framework/macaw.rb
+++ b/lib/macaw_framework/macaw.rb
@@ -218,10 +218,17 @@ class MacawFramework::Macaw
     @routes = []
     @cached_methods = {}
     @macaw_log ||= custom_log
-    @config = JSON.parse(File.read('application.json'))
+    config_file = ENV.fetch('MACAW_CONFIG', 'application.json')
+    @config = JSON.parse(File.read(config_file))
     @port = @config['macaw']['port'] || 8080
     @bind = @config['macaw']['bind'] || 'localhost'
     @threads = @config['macaw']['threads'] || 200
+  rescue Errno::ENOENT
+    @macaw_log&.warn("Config file '#{config_file}' not found, using default settings.")
+    @config = { 'macaw' => {} }
+  rescue JSON::ParserError => e
+    @macaw_log&.warn("Config file '#{config_file}' is not valid JSON: #{e.message}. Using default settings.")
+    @config = { 'macaw' => {} }
   end
 
   def setup_prometheus

--- a/lib/macaw_framework/middlewares/memory_invalidation_middleware.rb
+++ b/lib/macaw_framework/middlewares/memory_invalidation_middleware.rb
@@ -18,7 +18,6 @@ class MemoryInvalidationMiddleware
           end
         end
       rescue StandardError => e
-        # Log and continue so the eviction thread never dies silently
         warn "MemoryInvalidationMiddleware eviction error: #{e.message}"
       end
     end

--- a/lib/macaw_framework/middlewares/memory_invalidation_middleware.rb
+++ b/lib/macaw_framework/middlewares/memory_invalidation_middleware.rb
@@ -17,8 +17,10 @@ class MemoryInvalidationMiddleware
             @cache.delete(key) if Time.now - value[1] >= inv_time_seconds
           end
         end
+      rescue StandardError => e
+        # Log and continue so the eviction thread never dies silently
+        warn "MemoryInvalidationMiddleware eviction error: #{e.message}"
       end
     end
-    sleep(2)
   end
 end

--- a/lib/macaw_framework/middlewares/prometheus_middleware.rb
+++ b/lib/macaw_framework/middlewares/prometheus_middleware.rb
@@ -42,7 +42,8 @@ class PrometheusMiddleware
   def prometheus_endpoint(prometheus_registry, configurations, macaw)
     endpoint = configurations['macaw']['prometheus']['endpoint'] || '/metrics'
     macaw.get(endpoint) do |_context|
-      [Prometheus::Client::Formats::Text.marshal(prometheus_registry), 200, { 'Content-Type' => 'plaintext' }]
+      [Prometheus::Client::Formats::Text.marshal(prometheus_registry), 200,
+       { 'Content-Type' => 'text/plain; version=0.0.4; charset=utf-8' }]
     end
   end
 end

--- a/lib/macaw_framework/utils/supported_ssl_versions.rb
+++ b/lib/macaw_framework/utils/supported_ssl_versions.rb
@@ -3,9 +3,9 @@
 require 'openssl'
 
 module SupportedSSLVersions
+  # SSL2 and SSL3 are cryptographically broken (POODLE, DROWN) and removed.
+  # TLS 1.1 is deprecated by RFC 8996; prefer TLS 1.2 or TLS 1.3.
   VERSIONS = {
-    'SSL2' => OpenSSL::SSL::SSL2_VERSION,
-    'SSL3' => OpenSSL::SSL::SSL3_VERSION,
     'TLS1.1' => OpenSSL::SSL::TLS1_1_VERSION,
     'TLS1.2' => OpenSSL::SSL::TLS1_2_VERSION,
     'TLS1.3' => OpenSSL::SSL::TLS1_3_VERSION

--- a/lib/macaw_framework/utils/supported_ssl_versions.rb
+++ b/lib/macaw_framework/utils/supported_ssl_versions.rb
@@ -3,8 +3,6 @@
 require 'openssl'
 
 module SupportedSSLVersions
-  # SSL2 and SSL3 are cryptographically broken (POODLE, DROWN) and removed.
-  # TLS 1.1 is deprecated by RFC 8996; prefer TLS 1.2 or TLS 1.3.
   VERSIONS = {
     'TLS1.1' => OpenSSL::SSL::TLS1_1_VERSION,
     'TLS1.2' => OpenSSL::SSL::TLS1_2_VERSION,

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = '1.4.2'
+  VERSION = '1.4.3'
 end

--- a/macaw_framework.gemspec
+++ b/macaw_framework.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 created for study purposes, now production-ready and open for contributions."
   spec.homepage = 'https://github.com/ariasdiniz/macaw_framework'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.metadata['documentation_uri'] = 'https://rubydoc.info/gems/macaw_framework'
   spec.metadata['homepage_uri'] = spec.homepage

--- a/test/test_request_data_filtering.rb
+++ b/test/test_request_data_filtering.rb
@@ -10,7 +10,7 @@ class TestRequestDataFiltering < Minitest::Test
     expected_headers = {
       'Content-Type' => 'application/json',
       'Accept' => '*/*',
-      'Host' => 'localhost',
+      'Host' => 'localhost:8080',
       'Content-Length' => '29'
     }
     expected_body = "{\n    \"testBody\": \"testing\"\n}"
@@ -36,7 +36,7 @@ class TestRequestDataFiltering < Minitest::Test
     expected_headers = {
       'Content-Type' => 'application/json',
       'Accept' => '*/*',
-      'Host' => 'localhost',
+      'Host' => 'localhost:8080',
       'Content-Length' => '29'
     }
     expected_body = "{\n    \"testBody\": \"testing\"\n}"
@@ -63,7 +63,7 @@ class TestRequestDataFiltering < Minitest::Test
     expected_headers = {
       'Content-Type' => 'application/json',
       'Accept' => '*/*',
-      'Host' => 'localhost',
+      'Host' => 'localhost:8080',
       'Content-Length' => '29'
     }
     expected_body = "{\n    \"testBody\": \"testing\"\n}"

--- a/test/test_response_data_filter.rb
+++ b/test/test_response_data_filter.rb
@@ -9,7 +9,7 @@ class TestResponseDataFilter < Minitest::Test
     headers = { 'Content-Type' => 'text/html' }
     body = 'Hello, World!'
 
-    expected_response = "HTTP/1.1 200 OK \r\nContent-Type: text/html\r\n\r\nHello, World!"
+    expected_response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\nHello, World!"
     actual_response = ResponseDataFilter.mount_response(status, headers, body)
 
     assert_equal expected_response, actual_response
@@ -20,7 +20,7 @@ class TestResponseDataFilter < Minitest::Test
     headers = nil
     body = 'Hello, World!'
 
-    expected_response = "HTTP/1.1 200 OK \r\n\r\nHello, World!"
+    expected_response = "HTTP/1.1 200 OK\r\n\r\nHello, World!"
     actual_response = ResponseDataFilter.mount_response(status, headers, body)
 
     assert_equal expected_response, actual_response
@@ -29,7 +29,7 @@ class TestResponseDataFilter < Minitest::Test
   def test_mount_first_response_line_with_headers
     status = 200
     headers = { 'Content-Type' => 'text/html' }
-    expected_status_line = "HTTP/1.1 200 OK \r\n"
+    expected_status_line = "HTTP/1.1 200 OK\r\n"
     actual_status_line = ResponseDataFilter.mount_first_response_line(status, headers)
 
     assert_equal expected_status_line, actual_status_line
@@ -38,7 +38,7 @@ class TestResponseDataFilter < Minitest::Test
   def test_mount_first_response_line_without_headers
     status = 200
     headers = nil
-    expected_status_line = "HTTP/1.1 200 OK \r\n\r\n"
+    expected_status_line = "HTTP/1.1 200 OK\r\n\r\n"
     actual_status_line = ResponseDataFilter.mount_first_response_line(status, headers)
 
     assert_equal expected_status_line, actual_status_line

--- a/test/test_thread_server.rb
+++ b/test/test_thread_server.rb
@@ -11,7 +11,8 @@ require_relative '../lib/macaw_framework/data_filters/request_data_filtering'
 require_relative '../lib/macaw_framework/errors/endpoint_not_mapped_error'
 
 class TestEndpoint
-  attr_reader :routes, :port, :bind, :threads, :macaw_log, :cached_methods, :secure_header, :session
+  attr_reader :routes, :port, :bind, :threads, :macaw_log, :cached_methods, :secure_header, :session,
+              :keep_alive_timeout
   attr_accessor :config
 
   def initialize
@@ -24,6 +25,7 @@ class TestEndpoint
     @cached_methods = []
     @secure_header = 'X-Session-ID'
     @session = true
+    @keep_alive_timeout = 30
     define_singleton_method('get.hello', ->(_context) { 'Hello, World!' })
     define_singleton_method('get.ok', ->(_context) { ['Ok', 200] })
     define_singleton_method('get.ise', ->(_context) { raise StandardError, 'Internal server error' })
@@ -79,7 +81,7 @@ class ServerTest < Minitest::Test
 
     # Send a request to the server
     client = TCPSocket.new(@bind, @port)
-    client.puts "GET /hello HTTP/1.1\r\nHost: example.com\r\n\r\n"
+    client.puts "GET /hello HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
     response = client.read
     client.close
 
@@ -95,7 +97,7 @@ class ServerTest < Minitest::Test
     sleep(0.1)
 
     client = TCPSocket.new(@bind, @port)
-    client.puts "GET /nonexistent HTTP/1.1\r\nHost: example.com\r\n\r\n"
+    client.puts "GET /nonexistent HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
     response = client.read
     client.close
 
@@ -111,7 +113,7 @@ class ServerTest < Minitest::Test
     sleep(0.1)
 
     client = TCPSocket.new(@bind, @port)
-    client.puts "GET /ok HTTP/1.1\r\nHost: example.com\r\n\r\n"
+    client.puts "GET /ok HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
     response = client.read
     client.close
 
@@ -127,7 +129,7 @@ class ServerTest < Minitest::Test
     sleep(0.1)
 
     client = TCPSocket.new(@bind, @port)
-    client.puts "GET /ise HTTP/1.1\r\nHost: example.com\r\n\r\n"
+    client.puts "GET /ise HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
     response = client.read
     client.close
 
@@ -146,7 +148,7 @@ class ServerTest < Minitest::Test
     sleep(0.1)
 
     client = TCPSocket.new(@bind, @port)
-    client.puts "POST /hello HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n"
+    client.puts "POST /hello HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
     response = client.read
     client.close
 
@@ -193,7 +195,7 @@ class ServerTest < Minitest::Test
 
     # First request to set the session value
     client1 = TCPSocket.new(@bind, @port)
-    client1.puts "POST /set_session HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n"
+    client1.puts "POST /set_session HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
     response1 = client1.read
     session = response1.scan(/(X-Session-ID: (?:\w+-|\w+)+)/)[0][0].split(': ')[1]
     client1.close
@@ -202,7 +204,9 @@ class ServerTest < Minitest::Test
 
     # Second request to get the session value
     client2 = TCPSocket.new(@bind, @port)
-    client2.puts "GET /get_session HTTP/1.1\r\nHost: example.com\r\nX-Session-ID: #{session}\r\n\r\n"
+    req = "GET /get_session HTTP/1.1\r\nHost: example.com\r\n" \
+          "X-Session-ID: #{session}\r\nConnection: close\r\n\r\n"
+    client2.puts req
     response2 = client2.read
     client2.close
 
@@ -220,7 +224,7 @@ class ServerTest < Minitest::Test
     sleep(0.1)
 
     client1 = TCPSocket.new(@bind, @port)
-    client1.puts "POST /set_session HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n"
+    client1.puts "POST /set_session HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
     response1 = client1.read
     session = response1.scan(/(X-Session-ID: (?:\w+-|\w+)+)/)[0][0].split(': ')[1]
     client1.close
@@ -230,7 +234,9 @@ class ServerTest < Minitest::Test
     sleep(3.5)
 
     client2 = TCPSocket.new(@bind, @port)
-    client2.puts "GET /get_session HTTP/1.1\r\nHost: example.com\r\nX-Session-ID: #{session}\r\n\r\n"
+    req = "GET /get_session HTTP/1.1\r\nHost: example.com\r\n" \
+          "X-Session-ID: #{session}\r\nConnection: close\r\n\r\n"
+    client2.puts req
     response2 = client2.read
     client2.close
 
@@ -311,7 +317,7 @@ class ServerTest < Minitest::Test
     sleep(0.1)
 
     client = TCPSocket.new(@bind, @port)
-    client.puts "POST /test_filter HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhello"
+    client.puts "POST /test_filter HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"
     response = client.read
     client.close
 
@@ -378,7 +384,7 @@ class ServerTest < Minitest::Test
     10.times do
       threads << Thread.new do
         client = TCPSocket.new(@bind, @port)
-        client.puts "GET /hello HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        client.puts "GET /hello HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
         response = client.read
         client.close
         assert_match(/Hello, World!/, response)
@@ -400,11 +406,38 @@ class ServerTest < Minitest::Test
     sleep(0.1)
 
     client = TCPSocket.new(@bind, @port)
-    client.puts "GET /hello%24world HTTP/1.1\r\nHost: example.com\r\n\r\n"
+    client.puts "GET /hello%24world HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
     response = client.read
     client.close
 
     assert_match(/Hello, World!/, response)
+
+    @server.shutdown
+    server_thread.join
+  end
+
+  def test_keep_alive_reuses_connection
+    server_thread = Thread.new { @server.run }
+    sleep(0.1)
+
+    client = TCPSocket.new(@bind, @port)
+
+    # First request — no Connection: close, server should keep socket open
+    request = "GET /ok HTTP/1.1\r\nHost: example.com\r\n\r\n"
+    client.write request
+    first_response = +''
+    first_response << client.readpartial(4096) until first_response.include?("\r\n\r\n")
+
+    assert_match(%r{HTTP/1.1 200 OK}, first_response)
+    assert_match(/Connection: keep-alive/, first_response)
+
+    # Second request on the same connection — now close
+    client.write "GET /hello HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
+    second_response = client.read
+    client.close
+
+    assert_match(/Hello, World!/, second_response)
+    assert_match(/Connection: close/, second_response)
 
     @server.shutdown
     server_thread.join

--- a/test/test_thread_server.rb
+++ b/test/test_thread_server.rb
@@ -266,8 +266,8 @@ class ServerTest < Minitest::Test
     @macaw.config = {
       'macaw' => {
         'ssl' => {
-          'min' => 'SSL3',
-          'max' => 'TLS1.1',
+          'min' => 'TLS1.2',
+          'max' => 'TLS1.3',
           'cert_file_name' => './test/data/test_cert.pem',
           'key_file_name' => './test/data/test_key.pem'
         }
@@ -275,8 +275,8 @@ class ServerTest < Minitest::Test
     }
 
     context_mock = Minitest::Mock.new
-    context_mock.expect(:min_version=, nil, [OpenSSL::SSL::SSL3_VERSION])
-    context_mock.expect(:max_version=, nil, [OpenSSL::SSL::TLS1_1_VERSION])
+    context_mock.expect(:min_version=, nil, [OpenSSL::SSL::TLS1_2_VERSION])
+    context_mock.expect(:max_version=, nil, [OpenSSL::SSL::TLS1_3_VERSION])
     context_mock.expect(:cert=, nil, [Object])
     context_mock.expect(:key=, nil, [Object])
 


### PR DESCRIPTION
## Summary

This PR addresses a batch of correctness, thread-safety and protocol-compliance bugs
found during a code review, and adds HTTP/1.1 keep-alive support with a configurable
per-connection read timeout.

---

## Bug fixes

**Critical**
- `sanitize_parameter_value`: the first `gsub` result was discarded, leaving special
  characters in query parameter values completely unsanitized
- Header parsing regex (`[a-zA-Z0-9\-/*]`) silently dropped most real-world headers —
  `Authorization: Bearer …`, `Cookie:`, `User-Agent:`, `Host: localhost:8080` — replaced
  with a correct `\A[^:]+:\s*.+` regex and `split(':', 2)` to preserve colons in values
- `maintain_worker_pool` → `spawn_worker` **deadlock**: both methods tried to acquire the
  same non-reentrant `Mutex`; fixed by splitting `spawn_worker` into a lock-acquiring
  wrapper and a `create_worker` method called while already holding the lock
- `LogDataFilter`: `Digest::SHA256` was used without `require 'digest'`, causing
  `NameError` at runtime whenever a sensitive field matched

**Thread safety**
- `Cache#write` (else branch) and `Cache#read` — both now always synchronize on the
  internal mutex, eliminating TOCTOU races and non-atomic double updates
- `@session` hash — `declare_client_session` now synchronizes on a dedicated
  `@session_mutex`, preventing data races across worker threads

**Aspect chain**
- `LoggingAspect` and `PrometheusAspect` were calling `super(*args)` without
  `**kwargs`, silently dropping keyword arguments from upstream aspects; fixed to
  `super(*args, **kwargs)`
- `CacheAspect` held the cache mutex for the **entire endpoint execution** on a cache
  miss, serializing all requests to cached endpoints; endpoint now runs outside the lock
- `LoggingAspect` did not log anything despite its name — it now logs endpoint name,
  sanitized params, sanitized body, and response status on every call
- `PrometheusAspect` now uses `Process.clock_gettime(Process::CLOCK_MONOTONIC)` instead
  of `Time.now` for duration measurements

**Protocol & configuration**
- HTTP status line had a stray space before `\r\n` (`200 OK \r\n`), now RFC 7230 compliant
- Prometheus `/metrics` `Content-Type` corrected to `text/plain; version=0.0.4; charset=utf-8`
- `application.json` path is now configurable via `MACAW_CONFIG` env var; `Errno::ENOENT`
  and `JSON::ParserError` are rescued with a warning and safe defaults instead of crashing
- SSL2 and SSL3 removed from `SupportedSSLVersions` — both cryptographically broken
  (POODLE/DROWN) and absent from modern OpenSSL builds
- `frozen_string_literal: true` set consistently across all library files
- Eviction thread in `MemoryInvalidationMiddleware` now rescues `StandardError` so it
  never dies silently

**Startup latency**
- Removed `sleep(2)` from `MemoryInvalidationMiddleware` constructor
- Removed `sleep(1)` per cron job from `CronRunner#start_cron_job_thread`
- Removed duplicate `start_delay ||= 0` and always-true `unless start_delay.nil?` in
  `CronRunner`

---

## Feature: HTTP keep-alive

`handle_client` is now a request loop per accepted socket. The server processes multiple
requests on a single TCP connection without a new handshake, and only closes the socket
when the client sends `Connection: close`, disconnects, or the idle timeout fires.

Every response now carries a `Connection: keep-alive` or `Connection: close` header.

**Configurable timeout** (default 30 s) prevents idle or faulty clients from holding
worker threads indefinitely. It uses `IO#timeout=` on Ruby 3.2+ and falls back to
`SO_RCVTIMEO` via `setsockopt` for older Ruby and SSL sockets.

```json
{
  "macaw": {
    "keep_alive_timeout": 30
  }
}