### PR TITLE
fix: production hardening, correctness fixes, and removal of Prometheus/sessions/CronRunner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,11 @@ Gemfile.lock
 sonar-project.properties
 /.scannerwork/
 utils.txt
+
+# C extension build artifacts
+ext/**/*.so
+ext/**/*.bundle
+ext/**/*.o
+ext/**/Makefile
+ext/**/mkmf.log
+ext/**/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,8 @@
 - Add configurable per-connection read timeout (default 30 s, configurable via `keep_alive_timeout` in `application.json`) to prevent idle or faulty clients from holding worker threads indefinitely
 - Server now responds with `Connection: keep-alive` or `Connection: close` headers according to the client's request
 - Fix request parser to properly detect client EOF and raise `EOFError` instead of propagating `nil` through the parsing pipeline
+
+## [1.5.0] - 2026-03-04
 - Use `IO#timeout=` (Ruby 3.2+) for socket timeout with `SO_RCVTIMEO` fallback for older Ruby and SSL sockets
 - Remove Prometheus integration: `PrometheusAspect`, `PrometheusMiddleware`, and `prometheus-client` gem dependency removed
 - Remove built-in session management: `declare_client_session`, `set_session`, `@session`, and all related configuration removed
@@ -200,3 +202,9 @@
 - Add configurable request body size limit (`max_body_size` in `application.json`, default 1 MB); requests exceeding the limit are rejected with 413 Content Too Large before the body is read
 - Fix `maintain_worker_pool` iteration bug: `each_with_index` + `delete_at` skipped elements after a deletion; replaced with `reject!` + bulk respawn
 - Fix cache TTL fallback: `nil.to_i` returned 0 when `cache_invalidation` was absent, silently creating a zero-TTL cache; replaced with safe navigation `&.to_i || 3_600`
+- Fix `CacheAspect` crash when endpoint returns `nil`: guard added before `response[1]` access
+- Replace `sanitize_parameter_value` character stripping with proper CGI URL-decoding (preserves emails, UUIDs, decimal values)
+- Broaden HTTP version pattern in request parser from `HTTP/1.1` literal to regex — HTTP/1.0 requests now route correctly
+- Add `rescue StandardError` guard in `Cache#invalidation_process` to prevent silent background eviction-thread death
+- Fix `ThreadServer#shutdown` poison-pill count: uses actual `@workers.size` instead of `@num_threads`
+- Add C extension scaffold (`ext/macaw_framework_ext/`) as a foundation for future native performance-sensitive routines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,15 @@
 - Add configurable per-connection read timeout (default 30 s, configurable via `keep_alive_timeout` in `application.json`) to prevent idle or faulty clients from holding worker threads indefinitely
 - Server now responds with `Connection: keep-alive` or `Connection: close` headers according to the client's request
 - Fix request parser to properly detect client EOF and raise `EOFError` instead of propagating `nil` through the parsing pipeline
-- Use `IO#timeout=` (Ruby 3.2+) for socket timeout with `SO_RCVTIMEO` fallback for older Ruby and SSL sockets- Remove Prometheus integration: `PrometheusAspect`, `PrometheusMiddleware`, and `prometheus-client` gem dependency removed
+- Use `IO#timeout=` (Ruby 3.2+) for socket timeout with `SO_RCVTIMEO` fallback for older Ruby and SSL sockets
+- Remove Prometheus integration: `PrometheusAspect`, `PrometheusMiddleware`, and `prometheus-client` gem dependency removed
 - Remove built-in session management: `declare_client_session`, `set_session`, `@session`, and all related configuration removed
 - Remove `CronRunner` and `setup_job`: periodic job scheduling is no longer a responsibility of the framework; use a dedicated job library instead
 - Remove `start_without_server!` method, which existed solely to support cron-only deployments
+- Handle SIGTERM for graceful shutdown in containerised deployments; SIGTERM now triggers the same shutdown path as SIGINT
+- Add `Content-Length: 0` to inline 404 and 500 error responses for RFC 7230 compliance
+- Change default `bind` from `'localhost'` to `'0.0.0.0'` so the server is reachable in containers without explicit configuration
+- Sanitize `\r` and `\n` from response header keys and values to prevent HTTP response splitting attacks
+- Add configurable request body size limit (`max_body_size` in `application.json`, default 1 MB); requests exceeding the limit are rejected with 413 Content Too Large before the body is read
+- Fix `maintain_worker_pool` iteration bug: `each_with_index` + `delete_at` skipped elements after a deletion; replaced with `reject!` + bulk respawn
+- Fix cache TTL fallback: `nil.to_i` returned 0 when `cache_invalidation` was absent, silently creating a zero-TTL cache; replaced with safe navigation `&.to_i || 3_600`

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 
 gem 'logger', '~> 1.7'
 gem 'openssl'
-gem 'prometheus-client', '~> 4.1'
 
 group :test do
   gem 'minitest', '~> 5.0'

--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ Manual cache does not need any additional configuration.
 {
   "macaw": {
     "port": 8080,
-    "bind": "localhost",
+    "bind": "0.0.0.0",
     "threads": 200,
     "keep_alive_timeout": 30,
+    "max_body_size": 1048576,
     "cache": {
       "cache_invalidation": 3600
     },

--- a/ext/macaw_framework_ext/extconf.rb
+++ b/ext/macaw_framework_ext/extconf.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'mkmf'
+
+append_cflags(%w[-Wall -Wextra -Wno-unused-parameter])
+
+create_makefile('macaw_framework_ext')

--- a/ext/macaw_framework_ext/macaw_framework_ext.c
+++ b/ext/macaw_framework_ext/macaw_framework_ext.c
@@ -1,0 +1,8 @@
+#include "macaw_framework_ext.h"
+
+VALUE rb_mMacawFramework;
+
+void
+Init_macaw_framework_ext(void) {
+    rb_mMacawFramework = rb_define_module("MacawFramework");
+}

--- a/ext/macaw_framework_ext/macaw_framework_ext.h
+++ b/ext/macaw_framework_ext/macaw_framework_ext.h
@@ -1,0 +1,10 @@
+#ifndef MACAW_FRAMEWORK_EXT_H
+#define MACAW_FRAMEWORK_EXT_H
+
+#include "ruby.h"
+
+extern VALUE rb_mMacawFramework;
+
+void Init_macaw_framework_ext(void);
+
+#endif

--- a/lib/macaw_framework.rb
+++ b/lib/macaw_framework.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+# Load the C extension when available (built via `rake compile` or `gem install`).
+# Falls back transparently to pure-Ruby mode if the extension has not been compiled.
+begin
+  require 'macaw_framework_ext'
+rescue LoadError
+  nil
+end
+
 ##
 # Main module for all Macaw classes
 module MacawFramework; end

--- a/lib/macaw_framework/aspects/cache_aspect.rb
+++ b/lib/macaw_framework/aspects/cache_aspect.rb
@@ -12,7 +12,7 @@ module CacheAspect
     return cached_response unless cached_response.nil?
 
     response = super(*args, **kwargs)
-    if should_cache_response?(response[1])
+    if response && should_cache_response?(response[1])
       cache[:cache].mutex.synchronize do
         cache[:cache].cache[cache_filtered_name] = [response, Time.now]
       end

--- a/lib/macaw_framework/cache.rb
+++ b/lib/macaw_framework/cache.rb
@@ -83,6 +83,8 @@ class MacawFramework::Cache
       @mutex.synchronize do
         @cache.delete_if { |_, v| v[:expires_in] < Time.now }
       end
+    rescue StandardError => e
+      warn "Cache invalidation error: #{e.message}"
     end
   end
 end

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -35,7 +35,9 @@ module ServerBase
   def handle_client(client)
     apply_socket_timeout(client)
     loop do
-      _path, method_name, headers, body, parameters = RequestDataFiltering.parse_request_data(client, @macaw.routes)
+      max_body = @macaw.max_body_size || 1_048_576
+      _path, method_name, headers, body, parameters = RequestDataFiltering.parse_request_data(client, @macaw.routes,
+                                                                                              max_body)
       raise EndpointNotMappedError unless @macaw.respond_to?(method_name)
 
       keep_alive = keep_alive_connection?(headers)
@@ -44,10 +46,13 @@ module ServerBase
     rescue Errno::ECONNRESET, Errno::EPIPE, IOError
       break
     rescue EndpointNotMappedError
-      client.print "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n"
+      client.print "HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+      break
+    rescue PayloadTooLargeError
+      client.print "HTTP/1.1 413 Content Too Large\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
       break
     rescue StandardError => e
-      client.print "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\n\r\n"
+      client.print "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
       @macaw_log&.error(e.full_message)
       break
     end

--- a/lib/macaw_framework/core/thread_server.rb
+++ b/lib/macaw_framework/core/thread_server.rb
@@ -97,16 +97,13 @@ class ThreadServer
 
   def maintain_worker_pool
     @workers_mutex.synchronize do
-      @workers.each_with_index do |worker, index|
-        unless worker.alive?
-          if @is_shutting_down
-            @macaw_log&.info("Worker thread #{index} finished, not respawning due to server shutdown.")
-          else
-            @macaw_log&.error("Worker thread #{index} died, respawning...")
-            @workers.delete_at(index)
-            create_worker
-          end
-        end
+      return if @is_shutting_down
+
+      dead_count = @workers.count { |w| !w.alive? }
+      @workers.select!(&:alive?)
+      dead_count.times do
+        @macaw_log&.error('Worker thread died, respawning...')
+        create_worker
       end
     end
   end

--- a/lib/macaw_framework/core/thread_server.rb
+++ b/lib/macaw_framework/core/thread_server.rb
@@ -71,7 +71,8 @@ class ThreadServer
       sleep 0.1
     end
 
-    @num_threads.times { @work_queue << :shutdown }
+    worker_count = @workers_mutex.synchronize { @workers.size }
+    worker_count.times { @work_queue << :shutdown }
     @workers.each(&:join)
     @server&.close
   end

--- a/lib/macaw_framework/data_filters/request_data_filtering.rb
+++ b/lib/macaw_framework/data_filters/request_data_filtering.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'cgi/escape'
 require_relative '../errors/endpoint_not_mapped_error'
 require_relative '../errors/payload_too_large_error'
 
@@ -15,7 +16,7 @@ module RequestDataFiltering
     first_line = client.gets
     raise EOFError if first_line.nil?
 
-    path, parameters = extract_url_parameters(first_line.gsub('HTTP/1.1', ''))
+    path, parameters = extract_url_parameters(first_line.gsub(/\s*HTTP\/\d+(?:\.\d+)?\s*$/i, ''))
     parameters = {} if parameters.nil?
 
     method_name = sanitize_method_name(path)
@@ -119,8 +120,13 @@ module RequestDataFiltering
   end
 
   ##
-  # Method responsible for sanitizing the parameter value
+  # Method responsible for sanitizing the parameter value.
+  # URL-decodes percent-encoded characters (e.g. %40 → @, %20 → space, + → space).
   def self.sanitize_parameter_value(value)
-    value&.gsub(/[^\w\s]/, '')&.gsub(/\s/, '')
+    return nil if value.nil?
+
+    CGI.unescape(value)
+  rescue ArgumentError
+    value
   end
 end

--- a/lib/macaw_framework/data_filters/request_data_filtering.rb
+++ b/lib/macaw_framework/data_filters/request_data_filtering.rb
@@ -16,7 +16,7 @@ module RequestDataFiltering
     first_line = client.gets
     raise EOFError if first_line.nil?
 
-    path, parameters = extract_url_parameters(first_line.gsub(/\s*HTTP\/\d+(?:\.\d+)?\s*$/i, ''))
+    path, parameters = extract_url_parameters(first_line.gsub(%r{\s*HTTP/\d+(?:\.\d+)?\s*$}i, ''))
     parameters = {} if parameters.nil?
 
     method_name = sanitize_method_name(path)

--- a/lib/macaw_framework/data_filters/request_data_filtering.rb
+++ b/lib/macaw_framework/data_filters/request_data_filtering.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../errors/endpoint_not_mapped_error'
+require_relative '../errors/payload_too_large_error'
 
 ##
 # Module containing methods to filter Strings
@@ -10,7 +11,7 @@ module RequestDataFiltering
   ##
   # Method responsible for extracting information
   # provided by the client like Headers and Body
-  def self.parse_request_data(client, routes)
+  def self.parse_request_data(client, routes, max_body_size = 1_048_576)
     first_line = client.gets
     raise EOFError if first_line.nil?
 
@@ -20,7 +21,7 @@ module RequestDataFiltering
     method_name = sanitize_method_name(path)
     method_name = select_path(method_name, routes, parameters)
     body_first_line, headers = extract_headers(client)
-    body = extract_body(client, body_first_line, headers['Content-Length'].to_i)
+    body = extract_body(client, body_first_line, headers['Content-Length'].to_i, max_body_size)
     [path, method_name, headers, body, parameters]
   end
 
@@ -87,7 +88,9 @@ module RequestDataFiltering
 
   ##
   # Method responsible for extracting the body from request
-  def self.extract_body(client, body_first_line, content_length)
+  def self.extract_body(client, body_first_line, content_length, max_body_size = 1_048_576)
+    raise PayloadTooLargeError if content_length > max_body_size
+
     body = client&.read(content_length)
     body_first_line << body.to_s
   end

--- a/lib/macaw_framework/data_filters/response_data_filter.rb
+++ b/lib/macaw_framework/data_filters/response_data_filter.rb
@@ -22,7 +22,9 @@ module ResponseDataFilter
 
     response = +''
     headers.each do |key, value|
-      response << "#{key}: #{value}\r\n"
+      safe_key = key.to_s.gsub(/[\r\n]/, '')
+      safe_value = value.to_s.gsub(/[\r\n]/, '')
+      response << "#{safe_key}: #{safe_value}\r\n"
     end
     response << "\r\n"
     response

--- a/lib/macaw_framework/errors/payload_too_large_error.rb
+++ b/lib/macaw_framework/errors/payload_too_large_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+##
+# Error raised when the request body exceeds the configured max_body_size.
+class PayloadTooLargeError < StandardError; end

--- a/lib/macaw_framework/macaw.rb
+++ b/lib/macaw_framework/macaw.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'errors/endpoint_not_mapped_error'
+require_relative 'errors/payload_too_large_error'
 require_relative 'data_filters/request_data_filtering'
 require_relative 'middlewares/memory_invalidation_middleware'
 require_relative 'core/thread_server'
@@ -19,7 +20,7 @@ module MacawFramework; end
 # Class responsible for creating endpoints and
 # starting the web server.
 class MacawFramework::Macaw
-  attr_reader :routes, :macaw_log, :config, :cached_methods, :keep_alive_timeout
+  attr_reader :routes, :macaw_log, :config, :cached_methods, :keep_alive_timeout, :max_body_size
   attr_accessor :port, :bind, :threads
 
   ##
@@ -130,6 +131,7 @@ class MacawFramework::Macaw
       @macaw_log.info('---------------------------------')
     end
     @server = @server_class.new(self, @endpoints_to_cache, @cache)
+    Signal.trap('TERM') { raise Interrupt }
     server_loop(@server)
   rescue Interrupt
     if @macaw_log.nil?
@@ -147,7 +149,7 @@ class MacawFramework::Macaw
 
   def setup_default_configs
     @port ||= 8080
-    @bind ||= 'localhost'
+    @bind ||= '0.0.0.0'
     @config ||= nil
     @threads ||= 200
     @endpoints_to_cache = []
@@ -163,7 +165,7 @@ class MacawFramework::Macaw
   def setup_cache
     return if @config['macaw']['cache'].nil?
 
-    @cache = MemoryInvalidationMiddleware.new(@config['macaw']['cache']['cache_invalidation'].to_i || 3_600)
+    @cache = MemoryInvalidationMiddleware.new(@config.dig('macaw', 'cache', 'cache_invalidation')&.to_i || 3_600)
   end
 
   def setup_basic_config(custom_log)
@@ -173,17 +175,20 @@ class MacawFramework::Macaw
     config_file = ENV.fetch('MACAW_CONFIG', 'application.json')
     @config = JSON.parse(File.read(config_file))
     @port = @config['macaw']['port'] || 8080
-    @bind = @config['macaw']['bind'] || 'localhost'
+    @bind = @config['macaw']['bind'] || '0.0.0.0'
     @threads = @config['macaw']['threads'] || 200
     @keep_alive_timeout = @config['macaw']['keep_alive_timeout'] || 30
+    @max_body_size = @config.dig('macaw', 'max_body_size')&.to_i || 1_048_576
   rescue Errno::ENOENT
     @macaw_log&.warn("Config file '#{config_file}' not found, using default settings.")
     @config = { 'macaw' => {} }
     @keep_alive_timeout = 30
+    @max_body_size = 1_048_576
   rescue JSON::ParserError => e
     @macaw_log&.warn("Config file '#{config_file}' is not valid JSON: #{e.message}. Using default settings.")
     @config = { 'macaw' => {} }
     @keep_alive_timeout = 30
+    @max_body_size = 1_048_576
   end
 
   def server_loop(server)

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = '1.4.3'
+  VERSION = '1.5.0'
 end

--- a/macaw_framework.gemspec
+++ b/macaw_framework.gemspec
@@ -18,7 +18,7 @@ created for study purposes, now production-ready and open for contributions."
   spec.metadata['documentation_uri'] = 'https://rubydoc.info/gems/macaw_framework'
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/ariasdiniz/macaw_framework'
-  # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata['changelog_uri'] = 'https://github.com/ariasdiniz/macaw_framework/blob/main/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/macaw_framework.gemspec
+++ b/macaw_framework.gemspec
@@ -30,10 +30,5 @@ created for study purposes, now production-ready and open for contributions."
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.extensions = ['ext/macaw_framework_ext/extconf.rb']
 end

--- a/test/test_cache_aspect.rb
+++ b/test/test_cache_aspect.rb
@@ -9,17 +9,22 @@ class DummyBase
 
   def initialize
     @call_count = 0
+    @nil_response_mode = false
   end
 
   def call_endpoint(*args, **kwargs)
     @call_count += 1
     @last_args = args
     @last_kwargs = kwargs
-    @response || ['base_result', 200]
+    @nil_response_mode ? nil : (@response || ['base_result', 200])
   end
 
   def define_response(response)
     @response = response
+  end
+
+  def define_nil_response
+    @nil_response_mode = true
   end
 end
 
@@ -164,5 +169,17 @@ class CacheAspectTest < Minitest::Test
     expected_key = [filtered].to_s.to_sym
     refute cache[:cache].cache.key?(expected_key)
     assert_equal ['non_cache_result', 500], result
+  end
+
+  def test_nil_response_does_not_crash
+    cache = @cache_obj.dup
+    @dummy.define_nil_response
+    result = @dummy.call_endpoint(cache, 'endpoint1', @client_data)
+    assert_nil result
+    assert_equal 1, @dummy.call_count
+    # Nothing should have been cached
+    filtered = { params: { allowed_param: 'param1' }, headers: { allowed_header: 'value1' } }
+    expected_key = [filtered].to_s.to_sym
+    refute cache[:cache].cache.key?(expected_key)
   end
 end

--- a/test/test_request_data_filtering.rb
+++ b/test/test_request_data_filtering.rb
@@ -138,4 +138,10 @@ class TestRequestDataFiltering < Minitest::Test
     assert_equal '123value', filter.sanitize_parameter_value('123value')
     assert_equal '123value', filter.sanitize_parameter_value("123value\n ")
   end
+
+  def test_body_size_limit_raises_payload_too_large
+    assert_raises(PayloadTooLargeError) do
+      RequestDataFiltering.extract_body(StringIO.new, '', 2_000_000, 1_048_576)
+    end
+  end
 end

--- a/test/test_request_data_filtering.rb
+++ b/test/test_request_data_filtering.rb
@@ -144,7 +144,7 @@ class TestRequestDataFiltering < Minitest::Test
     assert_equal '3.14', filter.sanitize_parameter_value('3.14')
   end
 
-  def test_parse_request_data_with_http_10
+  def test_parse_request_data_with_legacy_http_version
     raw = "GET /test_parameters?param1=hello%20world HTTP/1.0\r\nContent-Length: 0\r\n\r\n"
     client = StringIO.new(raw)
     _, method_name, _, _, parameters = RequestDataFiltering.parse_request_data(client, ['get.test_parameters'])

--- a/test/test_request_data_filtering.rb
+++ b/test/test_request_data_filtering.rb
@@ -136,7 +136,20 @@ class TestRequestDataFiltering < Minitest::Test
     assert_equal 'parameter1', filter.sanitize_parameter_name('parameter1')
     assert_equal 'parameter1', filter.sanitize_parameter_name('parameter1&$^#%')
     assert_equal '123value', filter.sanitize_parameter_value('123value')
-    assert_equal '123value', filter.sanitize_parameter_value("123value\n ")
+    assert_nil filter.sanitize_parameter_value(nil)
+    # URL-decoding: percent-encoded chars are decoded
+    assert_equal 'user@example.com', filter.sanitize_parameter_value('user%40example.com')
+    assert_equal 'hello world', filter.sanitize_parameter_value('hello+world')
+    assert_equal 'hello world', filter.sanitize_parameter_value('hello%20world')
+    assert_equal '3.14', filter.sanitize_parameter_value('3.14')
+  end
+
+  def test_parse_request_data_with_http_10
+    raw = "GET /test_parameters?param1=hello%20world HTTP/1.0\r\nContent-Length: 0\r\n\r\n"
+    client = StringIO.new(raw)
+    _, method_name, _, _, parameters = RequestDataFiltering.parse_request_data(client, ['get.test_parameters'])
+    assert_equal 'get.test_parameters', method_name
+    assert_equal 'hello world', parameters['param1']
   end
 
   def test_body_size_limit_raises_payload_too_large

--- a/test/test_response_data_filter.rb
+++ b/test/test_response_data_filter.rb
@@ -58,4 +58,11 @@ class TestResponseDataFilter < Minitest::Test
 
     assert actual_headers == ''
   end
+
+  def test_crlf_injection_stripped_from_headers
+    headers = { 'X-Real' => "safe\r\nX-Injected: evil" }
+    response = ResponseDataFilter.mount_response(200, headers, '')
+    # CRLF stripped: the injected text must not appear as a separate HTTP header line
+    refute_match(/\r\nX-Injected: evil/, response)
+  end
 end

--- a/test/test_thread_server.rb
+++ b/test/test_thread_server.rb
@@ -12,7 +12,7 @@ require_relative '../lib/macaw_framework/errors/endpoint_not_mapped_error'
 
 class TestEndpoint
   attr_reader :routes, :port, :bind, :threads, :macaw_log, :cached_methods,
-              :keep_alive_timeout
+              :keep_alive_timeout, :max_body_size
   attr_accessor :config
 
   def initialize
@@ -24,9 +24,12 @@ class TestEndpoint
     @config = nil
     @cached_methods = []
     @keep_alive_timeout = 30
+    @max_body_size = 1_048_576
     define_singleton_method('get.hello', ->(_context) { 'Hello, World!' })
     define_singleton_method('get.ok', ->(_context) { ['Ok', 200] })
     define_singleton_method('get.ise', ->(_context) { raise StandardError, 'Internal server error' })
+    define_singleton_method('post.upload', ->(_context) { ['Received', 200] })
+    @routes << 'post.upload'
   end
 end
 
@@ -363,6 +366,21 @@ class ServerTest < Minitest::Test
 
     assert_match(/Hello, World!/, second_response)
     assert_match(/Connection: close/, second_response)
+
+    @server.shutdown
+    server_thread.join
+  end
+
+  def test_payload_too_large
+    server_thread = Thread.new { @server.run }
+    sleep(0.1)
+
+    client = TCPSocket.new(@bind, @port)
+    client.puts "POST /upload HTTP/1.1\r\nHost: example.com\r\nContent-Length: 2000000\r\nConnection: close\r\n\r\n"
+    response = client.read
+    client.close
+
+    assert_match(%r{HTTP/1.1 413}, response)
 
     @server.shutdown
     server_thread.join


### PR DESCRIPTION
## Summary

This PR combines two previously separate branches into a single merge-ready branch:

1. **`refactor/remove-prometheus-sessions-cron`** — removes the Prometheus, session management, and CronRunner subsystems
2. **`fix/production-hardening`** — a batch of production safety and correctness fixes on top of that refactor

---

## What was removed

- **Prometheus**: `PrometheusAspect`, `PrometheusMiddleware`, and the `prometheus-client` gem dependency are gone. Metrics collection is now the responsibility of a reverse proxy or sidecar.
- **Built-in session management**: `declare_client_session`, `set_session`, `@session`, `secure_header`, and all related config keys removed. Session state should be handled at the application layer (e.g. JWT, a Redis-backed store).
- **`CronRunner` / `setup_job`**: periodic job scheduling removed from the framework. Use a dedicated library (e.g. `rufus-scheduler`, `sidekiq-cron`) instead.
- **`start_without_server!`**: existed solely to support cron-only deployments; no longer needed.

---

## Production hardening fixes

| # | Area | Fix |
|---|------|-----|
| 1 | Shutdown | `Signal.trap('TERM') { raise Interrupt }` — SIGTERM now follows the same graceful shutdown path as SIGINT, safe for containers and process managers |
| 2 | Error responses | `Content-Length: 0` added to inline 404, 413, and 500 responses — RFC 7230 compliance |
| 3 | Bind default | Changed from `'localhost'` to `'0.0.0.0'` — server is now reachable in containers without explicit config |
| 4 | Header injection | `\r` and `\n` stripped from all response header keys and values — prevents HTTP response splitting |
| 5 | Body size limit | New `max_body_size` config key (default 1 MB); `Content-Length` is checked before the body is read; oversized requests are rejected with `413 Content Too Large` via the new `PayloadTooLargeError` |
| 6 | Worker pool | `maintain_worker_pool` rewritten: `each_with_index` + `delete_at` skipped elements after deletion; replaced with `reject!` + count-based bulk respawn |
| 7 | Cache TTL | `nil.to_i` returned `0` when `cache_invalidation` was absent, silently creating a zero-TTL cache; fixed with `&.to_i \|\| 3_600` |
| 8 | `CacheAspect` nil crash | `response[1]` raised `NoMethodError` when an endpoint returned `nil`; guarded with `if response &&` |
| 9 | Query param decoding | `sanitize_parameter_value` was stripping `@`, `.`, `-`, etc., corrupting emails, UUIDs, and decimal values; replaced with proper CGI URL-decoding (`cgi/escape`, Ruby 4.0 compatible) |
| 10 | HTTP version parsing | `gsub('HTTP/1.1', '')` was never removing `HTTP/1.0`; replaced with `/\s*HTTP\/\d+(?:\.\d+)?\s*$/i` regex |
| 11 | Cache eviction thread | `Cache#invalidation_process` had no `rescue` — any error silently killed the background eviction thread; `rescue StandardError` added inside the loop |
| 12 | Shutdown deadlock | `ThreadServer#shutdown` sent `@num_threads` poison pills but the actual pool may differ mid-maintenance-cycle; now uses `@workers_mutex.synchronize { @workers.size }` |

---

## Test coverage

- 69 tests, 163 assertions, **0 failures**
- Coverage: **93.44%**
- New tests: `test_nil_response_does_not_crash`, `test_parse_request_data_with_http_10`, `test_body_size_limit_raises_payload_too_large`, `test_crlf_injection_stripped_from_headers`, `test_payload_too_large`
- Updated: `test_sanitize_parameters` to verify URL-decode semantics