### PR TITLE
fix: explicit status and header returns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '4.0.1'
+          - '4.0.5'
           - '3.4.2'
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,3 +208,6 @@
 - Add `rescue StandardError` guard in `Cache#invalidation_process` to prevent silent background eviction-thread death
 - Fix `ThreadServer#shutdown` poison-pill count: uses actual `@workers.size` instead of `@num_threads`
 - Add C extension scaffold (`ext/macaw_framework_ext/`) as a foundation for future native performance-sensitive routines
+
+## [1.5.1]- 2026-06-07
+- Fix an error when running the server on Ruby 4.0.5 on MacOS that default values for status and headers on the response were not being set when these values are implicit on method declaration

--- a/lib/macaw_framework/core/common/server_base.rb
+++ b/lib/macaw_framework/core/common/server_base.rb
@@ -18,7 +18,7 @@ module ServerBase
   private
 
   def call_endpoint(name, client_data)
-    @macaw.send(
+    body, status, headers = @macaw.send(
       name.to_sym,
       {
         headers: client_data[:headers],
@@ -26,6 +26,7 @@ module ServerBase
         params: client_data[:params]
       }
     )
+    [body || '', status || 200, headers || {}]
   end
 
   def get_client_data(body, headers, parameters)

--- a/lib/macaw_framework/version.rb
+++ b/lib/macaw_framework/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MacawFramework
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
- This PR fixes a problem on ServerBase when running on MacOS, where the api status and headers were not set to default values when inplicit, causing malformed HTTP response and problems with the LoggingAspect.

- The fix was to add a default value after calling .send inside call_endpoint method, to prevent the error from propagating